### PR TITLE
Add "flush_interval" configuration parameter to force periodic publication to MQTT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+outage.txt
+kwlog.txt
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/genmqtt.conf
+++ b/genmqtt.conf
@@ -28,6 +28,11 @@ mqtt_address = 192.168.1.20
 # point number.
 # poll_interval =
 
+# Optional.  Flush Interval is the time in seconds where even unchanged values
+# will be published to their MQTT topic.  Default is a very large number that
+# effectively turns off flushing of unchanged values
+#flush_interval = 60
+
 # Optional. This value will be added to the begining of the MQTT path. The
 # default path used is 'generator/' however you could add set root_topic=Home
 # to make the path be Home/generator.


### PR DESCRIPTION
Add "flush_interval" configuration parameter which can ensure that
that a value is published, even if unchanged, after some interval
in seconds.

This may be useful if the data is being inserted into a database
for graphing to ensure that periodic samples of the data are
always available.