### PR TITLE
Fix crontab if wrong

### DIFF
--- a/genmonmaint.sh
+++ b/genmonmaint.sh
@@ -185,6 +185,14 @@ function updatecrontab() {
             echo "adding < $linetoadd > to crontab"
             echo "$linetoadd" >> $tempfile
             sudo crontab  $tempfile
+    elif [ "$result" != "$linetoadd" ]
+        then
+            echo "Crontab has an incorrect configuration, updating:"
+            echo "$result"
+            echo "to"
+            echo "$linetoadd"
+            sed -i "s~${result/\&\&/\\\&\\\&}~${linetoadd/\&\&/\\\&\\\&}~g" /tmp/gmtemp
+            sudo crontab $tempfile
         else
             echo "Crontab already contains genmon start script:"
             echo "$result"


### PR DESCRIPTION
Can be tested by making any edit to the line in the crontab file as long as it still has "startgenmon.sh" to be picked up by grep.