### PR TITLE
Login without SSL

### DIFF
--- a/conf/genmon.conf
+++ b/conf/genmon.conf
@@ -155,6 +155,15 @@ enhancedexercise = False
 # to be installed
 usehttps = False
 
+# (Optional) This parameter, if true, will enable the use of login when
+# HTTPS (secure HTTP) is disabled. This option is only applicable to the
+# web app and is not presented in the settings UI. Be sure you 
+# understand the risks of utilizing a username and password in 
+# clear-text and do not use a username and password that you use 
+# on any ohter systems.  The login options will have to be set manually
+# as well - http_user, http_pass, http_user_ro, http_pass_ro
+allowinsecurelogin = False
+
 # (Optional) This parameter is used with usehttps. If
 # userhttps is true, then this option will signal the type of certificate
 # to use. If this option is true  a self signed certificate (supplied by

--- a/genserv.py
+++ b/genserv.py
@@ -56,6 +56,7 @@ HTTPAuthUser_RO = None
 HTTPAuthPass_RO = None
 
 bUseSecureHTTP = False
+bInsecureLogin = False
 bUseSelfSignedCert = True
 SSLContext = None
 HTTPPort = 8000
@@ -1539,6 +1540,7 @@ def LoadConfig():
     global clientport
     global loglocation
     global bUseSecureHTTP
+    global bInsecureLogin
     global HTTPPort
     global HTTPAuthUser
     global HTTPAuthPass
@@ -1565,15 +1567,18 @@ def LoadConfig():
         if ConfigFiles[GENMON_CONFIG].HasOption('usehttps'):
             bUseSecureHTTP = ConfigFiles[GENMON_CONFIG].ReadValue('usehttps', return_type = bool)
 
+        if ConfigFiles[GENMON_CONFIG].HasOption('allowinsecurelogin'):
+            bInsecureLogin = ConfigFiles[GENMON_CONFIG].ReadValue('allowinsecurelogin', return_type = bool)
+
         if ConfigFiles[GENMON_CONFIG].HasOption('http_port'):
             HTTPPort = ConfigFiles[GENMON_CONFIG].ReadValue('http_port', return_type = int, default = 8000)
 
         if ConfigFiles[GENMON_CONFIG].HasOption('favicon'):
             favicon = ConfigFiles[GENMON_CONFIG].ReadValue('favicon')
 
-        # user name and password require usehttps = True
-        if bUseSecureHTTP:
+        if bUseSecureHTTP or bInsecureLogin:
             if ConfigFiles[GENMON_CONFIG].HasOption('http_user'):
+                app.secret_key = os.urandom(12)
                 HTTPAuthUser = ConfigFiles[GENMON_CONFIG].ReadValue('http_user', default = "")
                 HTTPAuthUser = HTTPAuthUser.strip()
                  # No user name or pass specified, disable
@@ -1594,10 +1599,8 @@ def LoadConfig():
                             HTTPAuthPass_RO = ConfigFiles[GENMON_CONFIG].ReadValue('http_pass_ro', default = "")
                             HTTPAuthPass_RO = HTTPAuthPass_RO.strip()
 
-            HTTPSPort = ConfigFiles[GENMON_CONFIG].ReadValue('https_port', return_type = int, default = 443)
-
         if bUseSecureHTTP:
-            app.secret_key = os.urandom(12)
+            HTTPSPort = ConfigFiles[GENMON_CONFIG].ReadValue('https_port', return_type = int, default = 443)
             OldHTTPPort = HTTPPort
             HTTPPort = HTTPSPort
             if ConfigFiles[GENMON_CONFIG].HasOption('useselfsignedcert'):


### PR DESCRIPTION
Support for login without SSL enabled.  Must set new allowinsecurelogin parameter manually as it does not show in UI.  Text added in config file warning of it. 