### PR TITLE
LDAP Support

### DIFF
--- a/conf/genmon.conf
+++ b/conf/genmon.conf
@@ -222,6 +222,28 @@ https_port = 443
 #            favicon=http://www.google.com/favicon.ico
 favicon =
 
+# (Optional) This parameter will allow the use of LDAP authentication. All 
+# of the LDAP options can only be configured manually in genmon.conf. This 
+# value will look like ldap://myserver.mydomain.com
+# The ldap_base and either admin or readonly groups must be specified. If
+# you do not understand any of these terms then you probably should ignore
+# the ldap options.
+ldap_server = 
+
+# (Optional) This parameter is required to use ldap and will look like 
+# dc=mydomain,dc=com
+ldap_base = 
+
+# (Optional) When using LDAP, this parameter specifies the group users 
+# must belong to for admin rights to genmon. This is a short name
+# such as "GenmonAdmins"
+ldap_admingroup = 
+
+# (Optional) When using LDAP, this parameter specifies the group users 
+# must belong to for readonly rights to genmon. This is a short name
+# such as "GenmonReadOnly"
+ldap_readonlygroup = 
+
 # A user defined URL link to include in status emails sent from the
 # software when the generator status changes
 user_url =

--- a/conf/genmon.conf
+++ b/conf/genmon.conf
@@ -155,6 +155,15 @@ enhancedexercise = False
 # to be installed
 usehttps = False
 
+# (Optional) This parameter, if true, will enable the use of login when
+# HTTPS (secure HTTP) is disabled. This option is only applicable to the
+# web app and is not presented in the settings UI. Be sure you 
+# understand the risks of utilizing a username and password in 
+# clear-text and do not use a username and password that you use 
+# on any ohter systems.  The login options will have to be set manually
+# as well - http_user, http_pass, http_user_ro, http_pass_ro
+allowinsecurelogin = False
+
 # (Optional) This parameter is used with usehttps. If
 # userhttps is true, then this option will signal the type of certificate
 # to use. If this option is true  a self signed certificate (supplied by

--- a/genserv.py
+++ b/genserv.py
@@ -56,6 +56,7 @@ HTTPAuthUser_RO = None
 HTTPAuthPass_RO = None
 
 bUseSecureHTTP = False
+bInsecureLogin = False
 bUseSelfSignedCert = True
 SSLContext = None
 HTTPPort = 8000
@@ -1539,6 +1540,7 @@ def LoadConfig():
     global clientport
     global loglocation
     global bUseSecureHTTP
+    global bInsecureLogin
     global HTTPPort
     global HTTPAuthUser
     global HTTPAuthPass
@@ -1565,15 +1567,18 @@ def LoadConfig():
         if ConfigFiles[GENMON_CONFIG].HasOption('usehttps'):
             bUseSecureHTTP = ConfigFiles[GENMON_CONFIG].ReadValue('usehttps', return_type = bool)
 
+        if ConfigFiles[GENMON_CONFIG].HasOption('allowinsecurelogin'):
+            bInsecureLogin = ConfigFiles[GENMON_CONFIG].ReadValue('allowinsecurelogin', return_type = bool)
+
         if ConfigFiles[GENMON_CONFIG].HasOption('http_port'):
             HTTPPort = ConfigFiles[GENMON_CONFIG].ReadValue('http_port', return_type = int, default = 8000)
 
         if ConfigFiles[GENMON_CONFIG].HasOption('favicon'):
             favicon = ConfigFiles[GENMON_CONFIG].ReadValue('favicon')
 
-        # user name and password require usehttps = True
-        if bUseSecureHTTP:
+        if bUseSecureHTTP or bInsecureLogin:
             if ConfigFiles[GENMON_CONFIG].HasOption('http_user'):
+                app.secret_key = os.urandom(12)
                 HTTPAuthUser = ConfigFiles[GENMON_CONFIG].ReadValue('http_user', default = "")
                 HTTPAuthUser = HTTPAuthUser.strip()
                  # No user name or pass specified, disable
@@ -1594,10 +1599,8 @@ def LoadConfig():
                             HTTPAuthPass_RO = ConfigFiles[GENMON_CONFIG].ReadValue('http_pass_ro', default = "")
                             HTTPAuthPass_RO = HTTPAuthPass_RO.strip()
 
-            HTTPSPort = ConfigFiles[GENMON_CONFIG].ReadValue('https_port', return_type = int, default = 443)
-
         if bUseSecureHTTP:
-            app.secret_key = os.urandom(12)
+            HTTPSPort = ConfigFiles[GENMON_CONFIG].ReadValue('https_port', return_type = int, default = 443)
             OldHTTPPort = HTTPPort
             HTTPPort = HTTPSPort
             if ConfigFiles[GENMON_CONFIG].HasOption('useselfsignedcert'):

--- a/genserv.py
+++ b/genserv.py
@@ -85,7 +85,7 @@ CachedRegisterDescriptions = {}
 def logout():
     try:
         # remove the session data
-        if HTTPAuthUser != None and HTTPAuthPass != None:
+        if HTTPAuthUser != None and HTTPAuthPass != None or LdapServer != None:
             session['logged_in'] = False
             session['write_access'] = False
         return root()
@@ -106,7 +106,7 @@ def add_header(r):
 @app.route('/', methods=['GET'])
 def root():
 
-    if HTTPAuthUser != None and HTTPAuthPass != None:
+    if HTTPAuthUser != None and HTTPAuthPass != None or LdapServer != None:
         if not session.get('logged_in'):
             return render_template('login.html')
         else:
@@ -118,7 +118,7 @@ def root():
 @app.route('/low', methods=['GET'])
 def lowbandwidth():
 
-    if HTTPAuthUser != None and HTTPAuthPass != None:
+    if HTTPAuthUser != None and HTTPAuthPass != None or LdapServer != None:
         if not session.get('logged_in'):
             return render_template('index_lowbandwith.html')
         else:
@@ -130,7 +130,7 @@ def lowbandwidth():
 @app.route('/internal', methods=['GET'])
 def display_internal():
 
-    if HTTPAuthUser != None and HTTPAuthPass != None:
+    if HTTPAuthUser != None and HTTPAuthPass != None or LdapServer != None:
         if not session.get('logged_in'):
             return render_template('login.html')
         else:
@@ -192,7 +192,6 @@ def doLdapLogin(username, password):
         if type(result[1]) is dict:
             for groupList in result[1].values():
                 for group in groupList:
-                    LogError("Group: " + group)
                     if group.upper().find("CN="+LdapAdminGroup.upper()+",") >= 0:
                         HasAdmin = True
                     elif group.upper().find("CN="+LdapReadOnlyGroup.upper()+",") >= 0:

--- a/genserv.py
+++ b/genserv.py
@@ -54,9 +54,12 @@ HTTPAuthUser = None
 HTTPAuthPass = None
 HTTPAuthUser_RO = None
 HTTPAuthPass_RO = None
+LdapServer = None
+LdapBase = None
+LdapAdminGroup = None
+LdapReadOnlyGroup = None
 
 bUseSecureHTTP = False
-bInsecureLogin = False
 bUseSelfSignedCert = True
 SSLContext = None
 HTTPPort = 8000
@@ -149,8 +152,62 @@ def do_admin_login():
         session['write_access'] = False
         LogError("Limited Rights Login")
         return root()
+    elif doLdapLogin(request.form['username'], request.form['password']):
+        return root()
+    elif request.form['username'] != "":
+        LogError("Invalid login: " + request.form['username'])
+        return render_template('login.html')
     else:
         return render_template('login.html')
+
+#-------------------------------------------------------------------------------
+def doLdapLogin(username, password):
+    if LdapServer == None or LdapServer == "":
+        return False
+    try:
+        import ldap
+    except ImportError:
+        LogError("LDAP import not found, run 'sudo apt-get -y install python-ldap'")
+        return False
+
+    conn = ldap.initialize(LdapServer)
+    conn.protocol_version = 3
+    conn.set_option(ldap.OPT_REFERRALS, 0)
+    try:
+        conn.simple_bind_s(username, password)
+    except:
+        LogError("Invalid login via LDAP: " + username)
+        return False
+
+    HasAdmin = False
+    HasReadOnly = False
+    SplitName = username.split('\\')
+    AccountName = SplitName[1]
+    AccountName = AccountName.strip()
+    ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+    search_filter="(&(objectClass=*)(member=uid="+AccountName+",$LdapBase))"
+    account_filter = "sAMAccountName="+AccountName
+    results = conn.search_s(LdapBase, ldap.SCOPE_SUBTREE, account_filter, ['memberOf'])
+    for result in results:
+        if type(result[1]) is dict:
+            for groupList in result[1].values():
+                for group in groupList:
+                    LogError("Group: " + group)
+                    if group.upper().find("CN="+LdapAdminGroup.upper()+",") >= 0:
+                        HasAdmin = True
+                    elif group.upper().find("CN="+LdapReadOnlyGroup.upper()+",") >= 0:
+                        HasReadOnly = True
+
+    session['logged_in'] = HasAdmin or HasReadOnly
+    session['write_access'] = HasAdmin
+    if HasAdmin:
+        LogError("Admin Login via LDAP")
+    elif HasReadOnly:
+        LogError("Limited Rights Login via LDAP")
+    else:
+        LogError("No rights for valid login via LDAP")
+
+    return HasAdmin or HasReadOnly
 
 #-------------------------------------------------------------------------------
 @app.route("/cmd/<command>")
@@ -1540,7 +1597,11 @@ def LoadConfig():
     global clientport
     global loglocation
     global bUseSecureHTTP
-    global bInsecureLogin
+    global LdapServer
+    global LdapBase
+    global LdapAdminGroup
+    global LdapReadOnlyGroup
+
     global HTTPPort
     global HTTPAuthUser
     global HTTPAuthPass
@@ -1552,6 +1613,11 @@ def LoadConfig():
     HTTPAuthPass = None
     HTTPAuthUser = None
     SSLContext = None
+    LdapServer = None
+    LdapBase = None
+    LdapAdminGroup = None
+    LdapReadOnlyGroup = None
+
     try:
 
         # heartbeat server port, must match value in check_generator_system.py and any calling client apps
@@ -1567,18 +1633,36 @@ def LoadConfig():
         if ConfigFiles[GENMON_CONFIG].HasOption('usehttps'):
             bUseSecureHTTP = ConfigFiles[GENMON_CONFIG].ReadValue('usehttps', return_type = bool)
 
-        if ConfigFiles[GENMON_CONFIG].HasOption('allowinsecurelogin'):
-            bInsecureLogin = ConfigFiles[GENMON_CONFIG].ReadValue('allowinsecurelogin', return_type = bool)
-
         if ConfigFiles[GENMON_CONFIG].HasOption('http_port'):
             HTTPPort = ConfigFiles[GENMON_CONFIG].ReadValue('http_port', return_type = int, default = 8000)
 
         if ConfigFiles[GENMON_CONFIG].HasOption('favicon'):
             favicon = ConfigFiles[GENMON_CONFIG].ReadValue('favicon')
 
-        if bUseSecureHTTP or bInsecureLogin:
+        # user name and password require usehttps = True
+        if bUseSecureHTTP:
+            if ConfigFiles[GENMON_CONFIG].HasOption('ldap_server'):
+                LdapServer = ConfigFiles[GENMON_CONFIG].ReadValue('ldap_server', default = "")
+                LdapServer = LdapServer.strip()
+                if LdapServer == "":
+                    LdapServer = None
+                else:
+                    if ConfigFiles[GENMON_CONFIG].HasOption('ldap_base'):
+                        LdapBase = ConfigFiles[GENMON_CONFIG].ReadValue('ldap_base', default = "")
+                    if ConfigFiles[GENMON_CONFIG].HasOption('ldap_admingroup'):
+                        LdapAdminGroup = ConfigFiles[GENMON_CONFIG].ReadValue('ldap_admingroup', default = "")
+                    if ConfigFiles[GENMON_CONFIG].HasOption('ldap_readonlygroup'):
+                        LdapReadOnlyGroup = ConfigFiles[GENMON_CONFIG].ReadValue('ldap_readonlygroup', default = "")
+                    if LdapBase == "":
+                        LdapBase = None
+                    if LdapAdminGroup == "":
+                        LdapAdminGroup = None
+                    if LdapReadOnlyGroup == "":
+                        LdapReadOnlyGroup = None
+                    if LdapReadOnlyGroup == None and LdapAdminGroup == None or LdapBase == None:
+                        LdapServer = None
+
             if ConfigFiles[GENMON_CONFIG].HasOption('http_user'):
-                app.secret_key = os.urandom(12)
                 HTTPAuthUser = ConfigFiles[GENMON_CONFIG].ReadValue('http_user', default = "")
                 HTTPAuthUser = HTTPAuthUser.strip()
                  # No user name or pass specified, disable
@@ -1599,8 +1683,10 @@ def LoadConfig():
                             HTTPAuthPass_RO = ConfigFiles[GENMON_CONFIG].ReadValue('http_pass_ro', default = "")
                             HTTPAuthPass_RO = HTTPAuthPass_RO.strip()
 
-        if bUseSecureHTTP:
             HTTPSPort = ConfigFiles[GENMON_CONFIG].ReadValue('https_port', return_type = int, default = 443)
+
+        if bUseSecureHTTP:
+            app.secret_key = os.urandom(12)
             OldHTTPPort = HTTPPort
             HTTPPort = HTTPSPort
             if ConfigFiles[GENMON_CONFIG].HasOption('useselfsignedcert'):


### PR DESCRIPTION
Config file editing only based on the conversation about insecure logins.  Supports admin & read only groups.  The single-accounts still work with LDAP enabled.  The additional import is also wrapped in error handling and only happens if ldap_server is specified in the config.