### PR TITLE
Add functionality to allow using I2C channels other than 1 or 2, by detectecting available I2C channels in /dev

### DIFF
--- a/genmonlib/gaugediy.py
+++ b/genmonlib/gaugediy.py
@@ -36,9 +36,9 @@ class GaugeDIY(MySupport):
         self.PollTime = self.config.ReadValue('poll_frequency', return_type = float, default = 60)
 
         self.i2c_channel = self.config.ReadValue('i2c_channel', return_type = int, default = 1)
-        available_i2c_channels = [int(n[len(I2C_DEV_PREFIX):]) for n in glob.glob(I2C_DEV_PREFIX + '[0-9]*')]
-        assert i2c_channel is not None, "No available i2c_channel found."
-        assert i2c_channel in available_i2c_channels, "'i2c_channel' must be one of {}".format(available_i2c_channels)
+        available_i2c_channels = [int(n[len(self.I2C_DEV_PREFIX):]) for n in glob.glob(self.I2C_DEV_PREFIX + '[0-9]*')]
+        assert self.i2c_channel is not None, "No available i2c_channel found."
+        assert self.i2c_channel in available_i2c_channels, "'i2c_channel' must be one of {}".format(available_i2c_channels)
 
         self.i2c_address = self.config.ReadValue('i2c_address', return_type = int, default = 72)  # 0x48
 

--- a/genmonlib/gaugediy.py
+++ b/genmonlib/gaugediy.py
@@ -13,13 +13,15 @@
 
 from __future__ import print_function
 
-import time, sys, os, math
+import glob, time, sys, os, math
 import smbus
 
 from genmonlib.myconfig import MyConfig
 from genmonlib.mysupport import MySupport
 
 class GaugeDIY(MySupport):
+    I2C_DEV_PREFIX = '/dev/i2c-'
+
     # ---------- GaugeDIY::__init__---------------------------------------------
     def __init__(self, config, log = None, console = None):
         super(GaugeDIY, self).__init__()
@@ -34,7 +36,9 @@ class GaugeDIY(MySupport):
         self.PollTime = self.config.ReadValue('poll_frequency', return_type = float, default = 60)
 
         self.i2c_channel = self.config.ReadValue('i2c_channel', return_type = int, default = 1)
-        assert self.i2c_channel in [1,2], "'i2c_channel' must be 1 or 2"
+        available_i2c_channels = [int(n[len(I2C_DEV_PREFIX):]) for n in glob.glob(I2C_DEV_PREFIX + '[0-9]*')]
+        assert i2c_channel is not None, "No available i2c_channel found."
+        assert i2c_channel in available_i2c_channels, "'i2c_channel' must be one of {}".format(available_i2c_channels)
 
         self.i2c_address = self.config.ReadValue('i2c_address', return_type = int, default = 72)  # 0x48
 


### PR DESCRIPTION
…
## Description

After configuring my Raspberry Pi, and i2c (which is not using the i2c-arm, but i2c-gpio as I had to move the default i2c pin away from GPIO 3 in my implementation), I ended up with /dev/i2c-11

```
pi@raspberrypi:~/git/genmon $ ls /dev/i2c*
/dev/i2c-11
```

After configuring gentankdiy to use channel 1, I saw this error:
```2021-01-11 09:04:53,656 : Error in GenTankData init: 'i2c_channel' must be 1 or 2 : gentankdiy.py:76```

Fixes # Only being able to use i2c channels 1 or 2

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested only on my Genmon installation, which has /dev/i2c-11

**Test Configuration**:
* Hardware: Raspberry Pi 3 B+
```
[    0.060086] raspberrypi-firmware soc:firmware: Attached to firmware from 2020-11-30 22:13, variant start
[    0.070100] raspberrypi-firmware soc:firmware: Firmware hash is ab1181cc0cb6df52bfae3b1d3fef0ce7c325166c
[    7.967297] brcmfmac mmc1:0001:1: Direct firmware load for brcm/brcmfmac43455-sdio.raspberrypi,3-model-b-plus.txt failed with error -2
[    8.224889] brcmfmac: brcmf_c_preinit_dcmds: Firmware: BCM4345/6 wl0: Mar 23 2020 02:19:54 version 7.45.206 (r725000 CY) FWID 01-88ee44ea
```
