### PR TITLE
Fixes MQTT reconnect issue

### DIFF
--- a/genmqtt.py
+++ b/genmqtt.py
@@ -457,9 +457,9 @@ class MyMQTT(MyCommon):
             self.LogErrorLine("Error in MyMQTT:PublishCallback: " + str(e1))
 
     #------------ MyMQTT::on_disconnect-----------------------------------------
-    def on_disconnect(client, userdata,rc=0):
+    def on_disconnect(self, client, userdata, rc=0):
 
-        self.LogError("DisConnected result code " + str(rc))
+        self.LogInfo("Disconnected from " + self.MQTTAddress + " result code: " + str(rc))
         self.MQTTclient.publish(self.LastWillTopic, payload = "Offline", retain = True)
 
 
@@ -470,7 +470,7 @@ class MyMQTT(MyCommon):
         try:
             if rc != 0:
                 self.LogError("Error connecting to MQTT server: return code: " + str(rc))
-            self.LogDebug("Connected with result code "+str(rc))
+            self.LogInfo("Connected to " + self.MQTTAddress + " result code: "+ str(rc))
 
             # Subscribing in on_connect() means that if we lose the connection and
             # reconnect then subscriptions will be renewed.


### PR DESCRIPTION

## Description

- Adds missing 'self' var on on_disconnect call, was causing MQTT thread to stop and never reconnect.

```
genmon@genmon:~/genmon $ python3 genmqtt.py -c /etc/genmon
OK : Auto, Off - Ready
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.7/dist-packages/paho/mqtt/client.py", line 3452, in _thread_main
    self.loop_forever(retry_first_connection=True)
  File "/usr/local/lib/python3.7/dist-packages/paho/mqtt/client.py", line 1779, in loop_forever
    rc = self.loop(timeout, max_packets)
  File "/usr/local/lib/python3.7/dist-packages/paho/mqtt/client.py", line 1181, in loop
    rc = self.loop_read(max_packets)
  File "/usr/local/lib/python3.7/dist-packages/paho/mqtt/client.py", line 1574, in loop_read
    return self._loop_rc_handle(rc)
  File "/usr/local/lib/python3.7/dist-packages/paho/mqtt/client.py", line 2227, in _loop_rc_handle
    self._do_on_disconnect(rc, properties)
  File "/usr/local/lib/python3.7/dist-packages/paho/mqtt/client.py", line 3360, in _do_on_disconnect
    self.on_disconnect(self, self._userdata, rc)
TypeError: on_disconnect() takes from 2 to 3 positional arguments but 4 were given
```


- Modify logging level to Info on connect/disconnect for easier tracking of connection state in logs, previously this would just be logged in debug mode which left the MQTT logs empty. Logging at Info level gives the user an idea of if connections are working properly or not from logs.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Connection failure test

Connection between genmon host and MQTT broker was severed by null-routing the broker's IP, on_disconnect ran as expected and logged accordingly, upon removal of null-route connection was recovered. Previously this would have resulted in a stacktrace if running the program in the foreground.

```
genmon@genmon:~/genmon $ python3 genmqtt.py -c /etc/genmon
OK : Auto, Off - Ready
Connected to 192.168.1.1 result code: 0
Disconnected from 192.168.1.1 result code: 1
Connected to 192.168.1.1 result code: 0
```

- [x] MQTT Info Logs as expected

```
genmon@genmon:~/genmon $ tail -3 /var/log/genmon/genmqtt.log
2021-02-05 16:01:42,875 : Connected to 192.168.1.1 result code: 0
2021-02-05 16:03:22,705 : Disconnected from 192.168.1.1 result code: 1
2021-02-05 16:03:39,011 : Connected to 192.168.1.1 result code: 0
```

**Test Configuration**:
* Firmware version: 1.15.17
* Hardware: Raspberry Pi 3 B+, Generac Evolution 2.0 Controller

## Checklist:

- [x] My code follows the existing code style and formatting of this project
- [x] I have performed a self-review of my own code
- [x] I have reasonably commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested any python code on 2.7 and 3.x
