### PR TITLE
Allow config of second tank name in add-ons

### DIFF
--- a/conf/gentankutil.conf
+++ b/conf/gentankutil.conf
@@ -18,3 +18,9 @@ password =
 # if multiple tanks are installed. If empty then the first tank found
 #  is used.
 tank_name =
+
+
+# tank name 2
+# If you have a second propane tank (and tank utility), enter the name
+# of your second tank here.
+tank_name_2 =

--- a/genserv.py
+++ b/genserv.py
@@ -1056,6 +1056,12 @@ def GetAddOns():
             "Tank name as defined in tankutility.com",
             bounds = 'minmax:1:50',
             display_name = "Tank Name")
+        AddOnCfg['gentankutil']['parameters']['tank_name_2'] = CreateAddOnParam(
+            ConfigFiles[GENTANKUTIL_CONFIG].ReadValue("tank_name_2", return_type=str, default=""),
+            'string',
+            "Second tank name, if applicable",
+            bounds='minmax:1:50',
+            display_name="Tank Name 2 (Optional)")
         AddOnCfg['gentankutil']['parameters']['username'] = CreateAddOnParam(
             ConfigFiles[GENTANKUTIL_CONFIG].ReadValue("username", return_type = str, default = ""),
             'string',


### PR DESCRIPTION
# Pull Request Template

## Description

This allows you to edit the name of tank_name_2 via the add-ons section of the web page.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested by manually updating genserv and verifying that parameter changed.

## Checklist:

- [X] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [X] I have reasonably commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested any python code on 3.x
- [X] I have tested any javascript on most popular browsers for compatibility
