### PR TITLE
GenMon SNMP - MIB and SMIv2 compliance

### DIFF
--- a/data/mib/README.md
+++ b/data/mib/README.md
@@ -1,0 +1,128 @@
+SNMP-MIB for GenMon.
+
+
+
+
+
+ABOUT:
+
+This MIB is provided to allow users and NMS applications to be able to query an
+SNMP-enabled GenMon installation using symbolic names rather than OIDs.
+
+The MIB in this directory assumes that the user is running GenMon with a 
+default Enterprise ID of '58399'.
+
+If the user wishes to change the enterprise ID, the change has to be made in 
+two locations:
+
+- The GenMon UI        (under "Add-ons", under the SNMP Support window.)
+- The MIB file itself. (change line 10 after the 'enterprises' keyword )
+
+Changing either location may cause the OIDs to not get mapped correctly and may
+cause unexpected errors in an SNMP-aware NMS. 
+
+
+FILES:
+genmon.mib    - The primary MIB file.
+
+
+GENERATOR SUPPORT:
+
+The MIB and underlying SNMP structure is controller agnostic however due to
+some OIDs only being used for specific controllers (or specific states of
+the generator), a blank response may be returned.
+
+Some OIDs will only return data if the generator is running, other OIDs will
+only return data for specific controllers (and again, only in certain states.)
+
+You can use snmptranslate to pull up a quick message about a particular OID.
+
+If the OID says:                       Then it will work on:
+(Evo/Nexus)                            Evolution or Nexus controllers.
+(h100)                                 H100 controllers.
+(h100/PowerZone)                       H100 or PowerZone controllers.
+(PowerZone)                            Only PowerZone controllers.
+(Any controller) or (Generic)          Any controller that works with GenMon.
+
+Be aware, some OIDs may not return data, even with the correct controller.
+A single phase H100 controller will not return data for GenMon-MIB::VoltageBC
+as that OID only populates for 3-phase generators.
+
+
+
+
+INSTALLATION:
+
+Installing these MIBs depends on which distribution or NMS application will be 
+monitoring GenMon.  For most cases, copying all .mib files in this directory
+to '/usr/share/snmp/mibs' is adequate,  Other distributions may require the
+MIBs be copied to another directory. 
+
+In some distributions, editing /etc/snmp/snmp.conf is necessary.  Locate the
+"mibs" line (it may or may not be commented out)
+
+and add "ALL" to the end of it:
+
+(Before) > mibs :
+(after)  > mibs ALL
+
+
+
+
+VERIFICATION:
+
+Verification of the MIBs can be performed using 'snmptranslate' as follows:
+
+> $ snmptranslate -Td GenMon-MIB::switchState
+
+which should return the following:
+
+> GenMon-MIB::switchState
+> switchState OBJECT-TYPE
+>   -- FROM	GenMon-MIB
+>   SYNTAX	OCTET STRING
+>   MAX-ACCESS	read-only
+>   STATUS	mandatory
+>   DESCRIPTION	"(All controllers) The current ready state of the generator based on control panel status. (Auto/Off/Manual)"
+> ::= { iso(1) org(3) dod(6) internet(1) private(4) enterprises(1) genmon(58399) controllerID(0) status(0) engineData(0) 1 }
+
+
+If the above produces a result as above, you're all set.  If it produces an 
+error like the one below, check the MIB search path and ensure the MIBs in this
+directory are in one of the directories in the MIB search path.
+
+> $ snmptranslate -Td GenMon-MIB::switchState
+> MIB search path: /home/matt/.snmp/mibs:/usr/share/snmp/mibs:/usr/share/ \
+>  snmp/mibs/iana:/usr/share/snmp/mibs/ietf:/usr/share/mibs/site:/usr/share \
+>  /snmp/mibs:/usr/share/mibs/iana:/usr/share/mibs/ietf:/usr/share/mibs/netsnmp
+> Cannot find module (GenMon-MIB): At line 1 in (none)
+> GenMon-MIB::switchState: Unknown Object Identifier
+
+Finally, query the GenMon controller using snmpget:
+
+> $ snmpget -v1 -c public (hostname_or_IP_of_genmon) GenMon-MIB::switchState
+
+It should answer with the below (assuming your generator is in Auto mode):
+
+> GenMon-MIB::switchState = STRING: "Auto"
+
+From there, snmpwalk can be used to retrieve the OID data.
+
+> $ snmpwalk -v1 -c public (hostname_or_IP_of_genmon) . 
+
+
+
+
+NAGIOS CONFIGURATION:
+
+Nagios contains a basic SNMP plugin called "check_snmp".  While the full
+capabilities of check_snmp are beyond the scope of this document, a basic 
+example is included below:
+
+> $ ./check_snmp -C public -H IP.ADDR.OF.GENMON -o GenMon-MIB::switchState \
+    -s \"Auto\"
+
+This command will return a CRITICAL status if the generator is not in "Auto" 
+state.  Using the -s parameter, you can set up Nagios to alert if the expected
+result string is not the result returned when polled.
+

--- a/data/mib/genmon.mib
+++ b/data/mib/genmon.mib
@@ -1,0 +1,1524 @@
+-- GenMon-MIB { iso(1) org(3) dod(6) internet(1) private(4) enterprises(1) genmon(9999) }
+
+GenMon-MIB DEFINITIONS ::= BEGIN
+
+IMPORTS
+   enterprises, OBJECT-TYPE, MODULE-IDENTITY                       FROM SNMPv2-SMI
+   DisplayString                                                   FROM SNMPv2-TC
+   MODULE-COMPLIANCE, OBJECT-GROUP                                 FROM SNMPv2-CONF;
+-- IMPORTS End
+
+genmon MODULE-IDENTITY
+    LAST-UPDATED "202201270000Z"
+    ORGANIZATION "GenMon - SNMP MIB"
+    CONTACT-INFO
+        "Please direct any requests for improvements, 
+         bugs, or other suggestions to the Github link below.
+         
+         Project Home - https://github.com/jgyates/genmon
+        "
+    DESCRIPTION
+       "This is the SNMP MIB definitions file for the Open Source GenMon project."
+
+    REVISION "202201270000Z"
+    DESCRIPTION
+       "Initial release."
+
+    ::= { enterprises 58399 }
+
+
+-- OID Subtree definitions
+
+-- 58399.x
+ monitor                       OBJECT IDENTIFIER ::= { genmon 0 }
+ evolution		       OBJECT IDENTIFIER ::= { genmon 1 }
+ h100                          OBJECT IDENTIFIER ::= { genmon 2 }
+ powerzone                     OBJECT IDENTIFIER ::= { genmon 3 }
+
+-- 58399.0.x
+ monitorHealth                 OBJECT IDENTIFIER ::= { monitor 0 }
+ commsStats                    OBJECT IDENTIFIER ::= { monitor 1 }
+ hwPlatformStatus              OBJECT IDENTIFIER ::= { monitor 2 }
+
+--58399.1.x
+ evStatus                      OBJECT IDENTIFIER ::= { evolution 0 }
+ evMaintenance                 OBJECT IDENTIFIER ::= { evolution 1 }
+ 
+--58399.1.0.x
+ evengine                      OBJECT IDENTIFIER ::= { evStatus 0 }
+ evline                        OBJECT IDENTIFIER ::= { evStatus 1 }
+ evlastAlarm                   OBJECT IDENTIFIER ::= { evStatus 2 }
+ evtime                        OBJECT IDENTIFIER ::= { evStatus 3 }
+ 
+--58399.1.1.x
+ evmaintenanceSettings        OBJECT IDENTIFIER ::= { evMaintenance 0 }
+ evcontrollerSettings         OBJECT IDENTIFIER ::= { evMaintenance 1 }
+ evexercise                   OBJECT IDENTIFIER ::= { evMaintenance 2 }
+ evservice                    OBJECT IDENTIFIER ::= { evMaintenance 3 }
+
+--58399.2.x
+ h100status                   OBJECT IDENTIFIER ::= { h100 0 }
+ 
+--58399.2.0.x
+ h1engine                     OBJECT IDENTIFIER ::= { h100status 0 }
+ h1alarms                     OBJECT IDENTIFIER ::= { h100status 1 }
+ h1battery                    OBJECT IDENTIFIER ::= { h100status 2 }
+ h1time                       OBJECT IDENTIFIER ::= { h100status 3 }
+ h1transferSwitch             OBJECT IDENTIFIER ::= { h100status 4 }
+
+--58399.3.x
+ pzstatus                     OBJECT IDENTIFIER ::= { powerzone 0 }
+ 
+--58399.3.0.x
+ pzengine                     OBJECT IDENTIFIER ::= { pzstatus 0 }
+ pzalarms                     OBJECT IDENTIFIER ::= { pzstatus 1 }
+ pzbattery                    OBJECT IDENTIFIER ::= { pzstatus 2 }
+ pztime                       OBJECT IDENTIFIER ::= { pzstatus 3 }
+
+
+-- SMIv2 Module Compliance statement
+gmCompliances MODULE-COMPLIANCE
+ STATUS current
+ DESCRIPTION
+  "Compliance statement for the entities in this GenMon MIB."
+ MODULE
+ MANDATORY-GROUPS {
+  gmMonitorMIBs,
+  evMonitorMIBs,
+  h1MonitorMIBs,
+  pzMonitorMIBs
+ }
+ ::= { monitor 3 }
+
+-- SMIv2 Module Compliance Groups
+
+gmMonitorMIBs OBJECT-GROUP
+  OBJECTS { gmMonHealth,
+            gmUptime,
+            gmPwrLogFileSize,
+            gmSWVersion,
+            serialPacketCount,
+            serialCRCErrors,
+            serialCRCPercentErrors,
+            serialTimeoutErrors,
+            serialTimeoutPercentErrors,
+            serialModbusExceptions,
+            serialValidationErrors,
+            serialInvalidData,
+            serialDiscardedBytes,
+            serialCommRestarts,
+            serialPktsPerSecond,
+            serialAvgTransactionTime,
+            piCPUTemp,
+            piHardwareModel,
+            piCPUFreqThrottle,
+            piARMFreqCap,
+            piUndervolt,
+            piCPUUtil,
+            piOSName,
+            piOSVersion,
+            piSysUptime,
+            piNICUsed }
+  STATUS current
+  DESCRIPTION
+    "A collection of objects that provide monitoring over the GenMon application and underlying Pi hardware."
+  ::= { monitor 4 }
+
+
+evMonitorMIBs OBJECT-GROUP
+  OBJECTS { switchState,
+            engineState,
+            activeRelays,
+            batteryVolts,
+            batteryStatus,
+            rpm,
+            frequency,
+            outputVoltage,
+            outputCurrent,
+            outputPower,
+            rotorPoles,
+            utilityVoltage,
+            utilityVoltageMin,
+            utilityVoltageMax,
+            utilityThresholdVoltage,
+            utilityPickupVoltage,
+            setOutputVoltage,
+            evLastAlarmLog,
+            evLastServiceLog,
+            evLastRunLog,
+            evMonitorTime,
+            evGeneratorTime,
+            generatorModel,
+            generatorSerial,
+            controller,
+            nominalRPM,
+            ratedKW,
+            ratedFreq,
+            fuelType,
+            fuelLevelSensor,
+            estFuelInTank,
+            displacement,
+            ambientTemp,
+            kwh30,
+            fuel30,
+            totalFuelUsed,
+            runHours30,
+            estHoursInTank,
+            loadHoursInTank,
+            fuelInTank,
+            fuelLevelState,
+            calCurrent1,
+            calCurrent2,
+            calVolts,
+            nominalLineVolts,
+            ratedMaxPower,
+            paramGroup,
+            voltageCode,
+            phase,
+            hoursProtection,
+            voltsPerHz,
+            gain,
+            targetFreq,
+            targetVolts,
+            exerciseTime,
+            exerciseDuration,
+            afDue,
+            oilDue,
+            spDue,
+            battServiceDue,
+            serviceADue,
+            serviceBDue,
+            batteryCheckDue,
+            totalRunHours,
+            hardwareVersion,
+            firmwareVersion }
+  STATUS current
+  DESCRIPTION
+    "A collection of all the OIDs for Evolution/Nexus controllers."
+  ::= { monitor 5 }
+
+
+h1MonitorMIBs OBJECT-GROUP
+  OBJECTS { h1switchState,
+            h1engineState,
+            h1generatorStatus,
+            h1outputPower,
+            h1outputPowerFactor,
+            h1rpm,
+            h1freq,
+            h1throttlePosition,
+            h1coolantTemp,
+            h1coolantLevel,
+            h1oilPressure,
+            h1oilTemp,
+            h1fuelLevel,
+            h1oxygenSensor,
+            h1currentPhaseA,
+            h1currentPhaseB,
+            h1currentPhaseC,
+            h1avgCurrent,
+            h1voltageAB,
+            h1voltageBC,
+            h1voltageCA,
+            h1avgVoltage,
+            h1airFuelDutyCycle,
+            h1activeAlarms,
+            h1ackedAlarms,
+            h1alarmList,
+            h1batteryVoltage,
+            h1batteryCurrent,
+            h1monitorTime,
+            h1generatorTime,
+            h1transferSwitchStatus }
+  STATUS current
+  DESCRIPTION
+    "A collection of all the OIDs for H-100 based controllers."
+  ::= { monitor 6 }
+
+
+pzMonitorMIBs OBJECT-GROUP
+  OBJECTS { pzSwitchState,
+            pzengineStatus,
+            pzgeneratorStatus,
+            pzoutputPower,
+            pzoutputPowerFactor,
+            pzrpm,
+            pzfrequency,
+            pzthrottlePosition,
+            pzcoolantTemp,
+            pzcoolantLevel,
+            pzoilPressure,
+            pzoilTemp,
+            pzfuelLevel,
+            pzoxygenSensor,
+            pzcurrentPhaseA,
+            pzcurrentPhaseB,
+            pzcurrentPhaseC,
+            pzavgCurrent,
+            pzvoltageAB,
+            pzvoltageBC,
+            pzvoltageCA,
+            pzavgVoltage,
+            pzairFuelDutyCycle,
+            pzalarmList,
+            pzbatteryVoltage,
+            pzbatteryCurrent,
+            pzmonitorTime,
+            pzgeneratorTime }
+  STATUS current
+  DESCRIPTION
+    "A collection of all the OIDs for PowerZone based controllers."
+  ::= { monitor 7 }
+
+
+--Objects
+
+--0.0.x (monitorHealth)
+
+gmMonHealth OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) GenMon internal health status."
+ ::= { monitorHealth 1 }
+
+gmUptime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) GenMon Application uptime (not to be confused with systemUpTime in the system MIB).  Essentially how long has GenMon been running."
+ ::= { monitorHealth 2 }
+
+gmPwrLogFileSize OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) GenMon Power Log File size (on disk)."
+ ::= { monitorHealth 3 }
+
+gmSWVersion OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) The currently installed software version of GenMon."
+ ::= { monitorHealth 4 }
+
+--0.1.x (commsStats)
+
+serialPacketCount OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many serial packets have been sent or received in total."
+ ::= { commsStats 1 }
+
+serialCRCErrors OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many serial packets had CRC errors. Too many CRC errors could inhibit effective communication with the controller. "
+ ::= { commsStats 2 }
+
+serialCRCPercentErrors OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many serial packets had CRC errors, expressed as a percent of total packets sent/received."
+ ::= { commsStats 3 }
+
+serialTimeoutErrors OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many serial packets timed out (didn't receive a response from the controller)."
+ ::= { commsStats 4 }
+
+serialTimeoutPercentErrors OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many serial packets timed out, expressed as a percent of total packets sent/received."
+ ::= { commsStats 5 }
+
+serialModbusExceptions OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many serial packets resulted in a Modbus exception (a communication fault)."
+ ::= { commsStats 6 }
+
+serialValidationErrors OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many serial packets failed validation.  Too many failed validation could cause communication problems."
+ ::= { commsStats 7 }
+
+serialInvalidData OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many serial packets contained invalid data.  This could be a sign of possible EMI/RF interference."
+ ::= { commsStats 8 }
+
+serialDiscardedBytes OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many bytes were discarded.  A high number might be a sign of possible EMI/RF interference. "
+ ::= { commsStats 9 }
+
+serialCommRestarts OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many times was the serial link restarted.  A high number might be a sign of possible EMI/RF interference."
+ ::= { commsStats 10 }
+
+serialPktsPerSecond OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How many packets per second is traversing the serial link to the generator controller."
+ ::= { commsStats 11 }
+
+serialAvgTransactionTime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) How much time does it take for the controller to respond to a transaction from Genmon.  Lower is better."
+ ::= { commsStats 12 }
+
+--0.2.x (hwPlatformStatus)
+
+piCPUTemp OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) The temperature reported by the CPU/SOC of the Raspberry Pi."
+ ::= { hwPlatformStatus 1 }
+
+piHardwareModel OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) Which Raspberry Pi is GenMon running on, including board version."
+ ::= { hwPlatformStatus 2 }
+
+piCPUFreqThrottle OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) This reports OK if the CPU is not throttling.  If it is throttling, it could be due to power delivery or high temperatures."
+ ::= { hwPlatformStatus 3 }
+
+piARMFreqCap OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) Is Raspberry Pi ARM Frequency Capping in effect. OK = no frequency capping."
+ ::= { hwPlatformStatus 4 }
+
+piUndervolt OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) Is the Raspberry Pi reporting a low voltage condition. OK = voltage good."
+ ::= { hwPlatformStatus 5 }
+
+piCPUUtil OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) The Raspberry Pi's CPU utilization represented as a percentage. Lower is better."
+ ::= { hwPlatformStatus 6 }
+
+piOSName OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) The Raspberry Pi's Operating System Name, e.g. 'Raspbian GNU/Linux'"
+ ::= { hwPlatformStatus 7 }
+
+piOSVersion OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) The Raspberry Pi's OS Version, e.g. '10 (Buster)'"
+ ::= { hwPlatformStatus 8 }
+
+piSysUptime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) The Raspberry Pi's OS Uptime."
+ ::= { hwPlatformStatus 9 }
+
+piNICUsed OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(All controllers) Which NIC is the Raspberry Pi using for network connectivity, e.g. eth0 (wired) or wlan0 (wifi)"
+ ::= { hwPlatformStatus 10 }
+
+--1.0.0.x (evolution.evstatus.evengine)
+
+switchState OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current ready state of the generator based on control panel status. (Auto/Off/Manual)"
+ ::= { evengine 1 }
+
+engineState OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current state of the generator's engine (Running/Exercising/Off) (Ready)"
+ ::= { evengine 2 }
+
+activeRelays OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION 
+  "(Evolution/Nexus) The current state of the optional relay kit's relays."
+ ::= { evengine 3 }
+
+batteryVolts OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current voltage of the generator's battery."
+ ::= { evengine 4 } 
+
+batteryStatus OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current state of the battery from the controller's perspective."
+ ::= { evengine 5 }
+
+rpm OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current RPM of the generator. Displays non-zero result when running, 0 if the engine is not running."
+ ::= { evengine 6 }
+
+frequency OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current output frequency of the generator. Displays non-zero result when running, 0 if the engine is not running."
+ ::= { evengine 7 }
+
+outputVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current output voltage of the generator.  Displays non-zero result when running, 0V if the engine is not running."
+ ::= { evengine 8 }
+
+outputCurrent OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The measured output current from the generator.  Displays non-zero result when running, 0A if the engine is not running."
+ ::= { evengine 9 }
+
+outputPower OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "{Evolution/Nexus) The calculated apparent power from the generator.  Displays non-zero result when running, 0 if the engine is not running."
+ ::= { evengine 10 } 
+
+rotorPoles OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "{Evolution/Nexus) The number of rotor poles the generator's coil has.  Displays non-zero when running, 0 if the engine is not running. Depends on generator hardware."
+ ::= { evengine 11 }
+
+-- 1.0.1.x (evline)
+
+utilityVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The measured incoming utility voltage."
+ ::= { evline 1 }
+
+utilityVoltageMin OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current lowest voltage read by the ATS."
+ ::= { evline 2 }
+
+utilityVoltageMax OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current highest voltage read by the ATS."
+ ::= { evline 3 }
+
+utilityThresholdVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The maximum voltage (per leg) before the ATS will trip and start the generator."
+ ::= { evline 4 }
+
+utilityPickupVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The minimum voltage (per leg) before the ATS will trip and start the generator."
+ ::= { evline 5 }
+
+setOutputVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current output voltage of the generator in a failover condition."
+ ::= { evline 6 }
+
+-- 1.0.2.x (evLastAlarm)
+
+evLastAlarmLog OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The last alarm entry in the controller's logs."
+ ::= { evlastAlarm 1 }
+
+evLastServiceLog OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The last service entry in the controller's logs."
+ ::= { evlastAlarm 2 }
+
+evLastRunLog OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The last run-log entry in the controller's logs."
+ ::= { evlastAlarm 3 }
+
+--1.0.3.x (evtime)
+
+evMonitorTime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current system time of GenMon."
+ ::= { evtime 1 }
+
+evGeneratorTime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current system time reported by the generator controller."
+ ::= { evtime 2 }
+
+-- 1.1.0.x (evmaintenanceSettings)
+
+generatorModel OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The generator model number as reported by the controller."
+ ::= { evmaintenanceSettings 1 }
+
+generatorSerial OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The generator's serial number as reported by the controller."
+ ::= { evmaintenanceSettings 2 }
+
+controller OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The controller detected by GenMon."
+ ::= { evmaintenanceSettings 3 }
+
+nominalRPM OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The currently configured normal RPM. (Usually 3600)."
+ ::= { evmaintenanceSettings 4 }
+
+ratedKW OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The designed maximum kW output (varies by generator)."
+ ::= { evmaintenanceSettings 5 }
+
+ratedFreq OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The designed output frequency of the generator (60Hz)."
+ ::= { evmaintenanceSettings 6 }
+
+fuelType OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The generator's input fuel type (CNG/LPG/Gasoline/Diesel)."
+ ::= { evmaintenanceSettings 7 }
+
+fuelLevelSensor OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The currently installed fuel sensor (Optional)."
+ ::= { evmaintenanceSettings 8 }
+
+estFuelInTank OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The controller's estimated fuel remaining in tank."
+ ::= { evmaintenanceSettings 9 }
+
+displacement OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The generator's engine displacement."
+ ::= { evmaintenanceSettings 10 }
+
+ambientTemp OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current ambient temperature as reported by the controller."
+ ::= { evmaintenanceSettings 11 }
+
+kwh30 OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The total amount of output kWh in the last 30 days."
+ ::= { evmaintenanceSettings 12 }
+
+fuel30 OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The total amount of fuel consumed in the last 30 days."
+ ::= { evmaintenanceSettings 13 }
+
+totalFuelUsed OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The total fuel used in the controller's lifetime."
+ ::= { evmaintenanceSettings 14 }
+
+runHours30 OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The total engine runtime in the last 30 days."
+ ::= { evmaintenanceSettings 15 }
+
+estHoursInTank OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The estimated runtime hours in the tank as calculated by the controller."
+ ::= { evmaintenanceSettings 16 }
+
+loadHoursInTank OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The estimated runtime hours remaining based on current load and estimated fuel in the generator's tank."
+ ::= { evmaintenanceSettings 17 }
+
+fuelInTank OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The remaining fuel in the tank based on the controller information.."
+ ::= { evmaintenanceSettings 18 }
+
+fuelLevelState OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current state of the fuel level as reported by the tank sensor."
+ ::= { evmaintenanceSettings 19 }
+
+--1.1.1.x (evcontrollerSettings)
+
+calCurrent1 OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) Calibration Current #1."
+ ::= { evcontrollerSettings 1 }
+
+calCurrent2 OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) Calibration Current #2."
+ ::= { evcontrollerSettings 2 }
+
+calVolts OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) Calibration Voltage."
+ ::= { evcontrollerSettings 3 }
+
+nominalLineVolts OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The controller-specified normal line voltage."
+ ::= { evcontrollerSettings 4 }
+
+ratedMaxPower OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The controller's configured rated maximum power."
+ ::= { evcontrollerSettings 5 }
+
+paramGroup OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The controller's configured parameter group."
+ ::= { evcontrollerSettings 6 }
+
+voltageCode OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The controller's configured voltage code."
+ ::= { evcontrollerSettings 7 }
+
+phase OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The controller's configured phase count."
+ ::= { evcontrollerSettings 8 }
+
+hoursProtection OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The expected available hours of protection calculated on a variety of different factors."
+ ::= { evcontrollerSettings 9 }
+
+voltsPerHz OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The measured voltage per Hz calculated from the controller's measurements."
+ ::= { evcontrollerSettings 10 }
+
+gain OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current setting of the exciter gain circuit in the generator's windings."
+ ::= { evcontrollerSettings 11 }
+
+targetFreq OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The target frequency that the generator is configured to run at.  Sudden load loss or add will affect the frequency, but this is the setting that the controller will try to stay at."
+ ::= { evcontrollerSettings 12 }
+
+targetVolts OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The target output voltage that the generator is configured to run at.  Changes in RPM will affect actual output voltage, but this is the setting that the controller will try to stay at."
+ ::= { evcontrollerSettings 13 }
+
+--1.1.2.x (evexercise)
+
+exerciseTime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The scheduled exercise date and time, e.g. every Wednesday at 1:00 PM."
+ ::= { evexercise 1 }
+
+exerciseDuration OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) When the controller executes the exercise cycle, this is how long the controller will run the engine."
+ ::= { evexercise 2 }
+
+--1.1.3.x (evservice)
+
+afDue OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The scheduled time of the next Air Filter replacement service."
+ ::= { evservice 1 }
+
+oilDue OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The scheduled time of the next oil change service."
+ ::= { evservice 2 }
+
+spDue OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The scheduled time of the next spark plug service."
+ ::= { evservice 3 }
+
+battServiceDue OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The scheduled time of the next Battery service."
+ ::= { evservice 4 }
+
+serviceADue OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The scheduled time of the next 'Service A' service."
+ ::= { evservice 5 }
+
+serviceBDue OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The scheduled time of the next 'Service B' service."
+ ::= { evservice 6 }
+
+batteryCheckDue OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The scheduled time of the next battery check."
+ ::= { evservice 7 }
+
+totalRunHours OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The total accrued controller runtime over the controller's lifespan."
+ ::= { evservice 8 }
+
+hardwareVersion OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current hardware version of the generator."
+ ::= { evservice 9 }
+
+firmwareVersion OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(Evolution/Nexus) The current firmware version of the generator controller."
+ ::= { evservice 10 }
+
+--2.0.0.x (h1engine)
+
+h1switchState OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current ready state of the generator controller (Ready/Manual/Off)."
+ ::= { h1engine 1 }
+
+h1engineState OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current state of the engine (Running/Off) (Ready)."
+ ::= { h1engine 2 }
+
+h1generatorStatus OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current state of the generator circuitry."
+ ::= { h1engine 3 }
+
+h1outputPower OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current output power as reported by the controller."
+ ::= { h1engine 4 }
+
+h1outputPowerFactor OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current output power factor as reported by the controller."
+ ::= { h1engine 5 }
+
+h1rpm OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current RPM of the engine as reported by the controller."
+ ::= { h1engine 6 }
+
+h1freq OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current output frequency of the generator as reported by the controller."
+ ::= { h1engine 7 }
+
+h1throttlePosition OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The engine's current throttle position as reported by the controller."
+ ::= { h1engine 8 }
+
+h1coolantTemp OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The engine's current coolant temperature as reported by the controller."
+ ::= { h1engine 9 }
+
+h1coolantLevel OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The engine's current coolant level as reported by the controller."
+ ::= { h1engine 10 }
+
+h1oilPressure OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The engine's current oil pressure level as reported by the controller.  This will read non-zero only when the engine is running."
+ ::= { h1engine 11 }
+
+h1oilTemp OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The engine's current oil temperature as reported by the controller."
+ ::= { h1engine 12 }
+
+h1fuelLevel OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The engine's current fuel level as reported by the controller."
+ ::= { h1engine 13 }
+
+h1oxygenSensor OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The engine's current O2 sensor reading."
+ ::= { h1engine 14 }
+
+h1currentPhaseA OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's phase A amperage."
+ ::= { h1engine 15 }
+
+h1currentPhaseB OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's phase B amperage."
+ ::= { h1engine 16 }
+
+h1currentPhaseC OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's phase C amperage."
+ ::= { h1engine 17 }
+
+h1avgCurrent OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's average current across all output phases."
+ ::= { h1engine 18 }
+
+h1voltageAB OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's voltage between A and B outputs."
+ ::= { h1engine 19 }
+
+h1voltageBC OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's voltage between B and C outputs."
+ ::= { h1engine 20 }
+
+h1voltageCA OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's voltage between C and A outputs."
+ ::= { h1engine 21 }
+
+h1avgVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's average voltage across all three phases."
+ ::= { h1engine 22 }
+
+h1airFuelDutyCycle OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The generator's current measured Air/Fuel duty cycle."
+ ::= { h1engine 23 }
+
+--2.0.1 Alarms
+
+h1activeAlarms OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The controller's currently active alarms."
+ ::= { h1alarms 1 }
+
+h1ackedAlarms OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The controller's currently acknowledged alarms."
+ ::= { h1alarms 2 }
+
+h1alarmList OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The controller's current alarm list (any state)."
+ ::= { h1alarms 3 }
+
+--2.0.2 (h1battery)
+
+h1batteryVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current battery voltage."
+ ::= { h1battery 1 }
+
+h1batteryCurrent OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current battery amperage (charge/discharge)."
+ ::= { h1battery 2 }
+
+--2.0.3 (h1time)
+
+h1monitorTime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current time reported by GenMon."
+ ::= { h1time 1 }
+
+h1generatorTime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(H100) The current time reported by the genrator's controller."
+ ::= { h1time 2 }
+
+--2.0.4 (h1transferSwitch)
+
+h1transferSwitchStatus OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only 
+ STATUS current
+ DESCRIPTION
+  "(H100) The current status of the Automatic Transfer Switch (ATS)."
+ ::= { h1transferSwitch 1 }
+
+--3.0.0 (pzengine)
+
+pzSwitchState OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current status of the generator's controller."
+ ::= { pzengine 1 }
+
+pzengineStatus OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current state of the engine (Running/Off)."
+ ::= { pzengine 2 }
+
+pzgeneratorStatus OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current state of the generator."
+ ::= { pzengine 3 }
+
+pzoutputPower OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The power output of the generator."
+ ::= { pzengine 4 }
+
+pzoutputPowerFactor OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current power factor of the generator load."
+ ::= { pzengine 5 }
+
+pzrpm OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current engine RPM. Returns 0 if the genrator is not running."
+ ::= { pzengine 6 }
+
+pzfrequency OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current output frequency of the generator. Returns 0 if the generator is not running."
+ ::= { pzengine 7 }
+
+pzthrottlePosition OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only 
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current throttle position of the generator."
+ ::= { pzengine 8 }
+
+pzcoolantTemp OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current temperature of the coolant in the generator."
+ ::= { pzengine 9 }
+
+pzcoolantLevel OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current state of the coolant level in the generator."
+ ::= { pzengine 10 }
+
+pzoilPressure OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current oil pressure of the generator.  Returns a non-zero value when the engine is running."
+ ::= { pzengine 11 }
+
+pzoilTemp OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current oil temperature of the generator."
+ ::= { pzengine 12 }
+
+pzfuelLevel OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current fuel level of the fuel tank."
+ ::= { pzengine 13 }
+
+pzoxygenSensor OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current O2 sensor reading."
+ ::= { pzengine 14 }
+
+pzcurrentPhaseA OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The amount of current draw on Phase A output."
+ ::= { pzengine 15 }
+
+pzcurrentPhaseB OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The amount of current draw on Phase B output."
+ ::= { pzengine 16 }
+
+pzcurrentPhaseC OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The amount of current draw on Phase C output."
+ ::= { pzengine 17 }
+
+pzavgCurrent OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The average current draw on all three phases."
+ ::= { pzengine 18 }
+
+pzvoltageAB OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The voltage output between output A and B."
+ ::= { pzengine 19 }
+
+pzvoltageBC OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The voltage output between output B and C."
+ ::= { pzengine 20 }
+
+pzvoltageCA OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The voltage output between output C and A."
+ ::= { pzengine 21 }
+
+pzavgVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The average voltage of all three outputs."
+ ::= { pzengine 22 }
+
+pzairFuelDutyCycle OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current air/fuel duty cycle of the generator."
+ ::= { pzengine 23 }
+
+--3.0.1 (pzalarms)
+
+pzalarmList OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current list of alarms as reported by the controller."
+ ::= { pzalarms 1 }
+
+--3.0.2 (pzbattery)
+
+pzbatteryVoltage OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current voltage of the battery."
+ ::= { pzbattery 1 }
+
+pzbatteryCurrent OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current amperage draw of the battery."
+ ::= { pzbattery 2 }
+
+--3.0.3 (pztime)
+
+pzmonitorTime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current time as reported by GenMon."
+ ::= { pztime 1 }
+
+pzgeneratorTime OBJECT-TYPE
+ SYNTAX DisplayString
+ MAX-ACCESS read-only
+ STATUS current
+ DESCRIPTION
+  "(PowerZone) The current time as reported by the generator controller."
+ ::= { pztime 2 }
+
+END

--- a/gensnmp.py
+++ b/gensnmp.py
@@ -78,7 +78,9 @@ class MyOID(MySupport):
                 return api.protoModules[protoVer].OctetString(self.value)
             elif self.return_type == int:
                 return api.protoModules[protoVer].Integer(self.value)
-            elif self.return_type == type(TimeTicks):
+            elif self.return_type == ObjectIdentifier:
+                return api.protoModules[protoVer].ObjectIdentifier(self.value)
+            elif self.return_type == TimeTicks:
                 return api.protoModules[protoVer].TimeTicks((time.time() - self.birthday) * 100)
             else:
                 self.LogError("Invalid type in MyOID: " + str(self.return_type))
@@ -112,7 +114,7 @@ class GenSNMP(MySupport):
 
         self.UseNumeric = False
         self.MonitorAddress = host
-        self.debug = False
+        self.debug = True
         self.PollTime = 1
         self.BlackList = ["Outage"] #["Monitor"]
         configfile = os.path.join(ConfigFilePath , 'gensnmp.conf')
@@ -131,7 +133,7 @@ class GenSNMP(MySupport):
             self.PollTime = self.config.ReadValue('poll_frequency', return_type = float, default = 1)
             self.debug = self.config.ReadValue('debug', return_type = bool, default = False)
             self.community = self.config.ReadValue('community', default = "public")
-            self.enterpriseID = self.config.ReadValue('enterpriseid', return_type = int, default = 9999)
+            self.enterpriseID = self.config.ReadValue('enterpriseid', return_type = int, default = 58399)
             self.baseOID = (1, 3, 6, 1, 4, 1, self.enterpriseID)
 
             if self.MonitorAddress == None or not len(self.MonitorAddress):
@@ -262,207 +264,212 @@ class GenSNMP(MySupport):
 
         try:
             if self.ControllerIsEvolutionNexus() or self.ControllerSelected == "generac_evo_nexus":
-                CtlID = 0
-            elif self.ControllerIsGeneracH100() or self.ControllerSelected == "h_100":
                 CtlID = 1
-            elif self.ControllerIsGeneracPowerZone() or self.ControllerSelected == "powerzone":
+            elif self.ControllerIsGeneracH100() or self.ControllerSelected == "h_100":
                 CtlID = 2
+            elif self.ControllerIsGeneracPowerZone() or self.ControllerSelected == "powerzone":
+                CtlID = 3
             else:
                 self.LogError("Error: Invalid controller type")
                 self.LogError(str(self.ControllerSelected))
                 return
 
-            self.mibData.append(MyOID((1,3,6,1,2,1,1,1),return_type = str, description = "SysDescr", default = "Genmon Generator Monitor",log = self.log))
-            self.mibData.append(MyOID((1,3,6,1,2,1,1,3,0),return_type = type(TimeTicks), description = "Uptime",log = self.log))
+            #Base OIDs required for core functionality
+            self.mibData.append(MyOID((1,3,6,1,2,1,1,1,0),return_type = str, description = "SysDescr", default = "Genmon Generator Monitor",log = self.log))
+            self.mibData.append(MyOID((1,3,6,1,2,1,1,2,0),return_type = ObjectIdentifier, description = "OID", default = ".1.3.6.1.4.1." + str(self.enterpriseID), log = self.log))
+            self.mibData.append(MyOID((1,3,6,1,2,1,1,3,0),return_type = TimeTicks, description = "Uptime", log = self.log))
+
+            #This info doesn't change regardless of what generator's attached.  So we'll use branch .0 from enterprises.58399. to avoid potential OID collisions.
+            # Monitor->Generator Monitor Stats - Included for all controllers enterprises.58399.0.x
+            self.AddOID((0,0,1),return_type = str, description = "MonitorHealth", default = "Unknown", keywords = ["Monitor","Monitor Health"])
+            self.AddOID((0,0,2),return_type = str, description = "RunTime", default = "Unknown", keywords = ["Monitor","Run time"])
+            self.AddOID((0,0,3),return_type = str, description = "PowerLogSize", default = "", keywords = ["Monitor","Power log file size"])
+            self.AddOID((0,0,4),return_type = str, description = "Version", default = "", keywords = ["Monitor","Generator Monitor Version"])
+            # Communication Stats - All controllers - enterprises.58399.1.x
+            self.AddOID((0,1,1),return_type = str, description = "PacketCount", default = "Unknown", keywords = ["Monitor/Communication Stats","Packet Count"])
+            self.AddOID((0,1,2),return_type = str, description = "CRCErrors", default = "Unknown", keywords = ["Monitor/Communication Stats","CRC Errors"])
+            self.AddOID((0,1,3),return_type = str, description = "CRCPercent", default = "Unknown", keywords = ["Monitor/Communication Stats","CRC Percent Errors"])
+            self.AddOID((0,1,4),return_type = str, description = "PacketTimeouts", default = "Unknown", keywords = ["Monitor/Communication Stats","Timeout Errors"])
+            self.AddOID((0,1,5),return_type = str, description = "TimeoutPercent", default = "Unknown", keywords = ["Monitor/Communication Stats","Timeout Percent Errors"])
+            self.AddOID((0,1,6),return_type = str, description = "ModbusErrors", default = "Unknown", keywords = ["Monitor/Communication Stats","Modbus Exceptions"])
+            self.AddOID((0,1,7),return_type = str, description = "ValidationErrors", default = "Unknown", keywords = ["Monitor/Communication Stats","Validation Errors"])
+            self.AddOID((0,1,8),return_type = str, description = "InvalidData", default = "Unknown", keywords = ["Monitor/Communication Stats","Invalid Data"])
+            self.AddOID((0,1,9),return_type = str, description = "DiscardedBytes", default = "Unknown", keywords = ["Monitor/Communication Stats","Discarded Bytes"])
+            self.AddOID((0,1,10),return_type = str, description = "CommRestarts", default = "Unknown", keywords = ["Monitor/Communication Stats","Comm Restarts"])
+            self.AddOID((0,1,11),return_type = str, description = "PPS", default = "Unknown", keywords = ["Monitor/Communication Stats","Packets Per Second"])
+            self.AddOID((0,1,12),return_type = str, description = "AvgTransTime", default = "Unknown", keywords = ["Monitor/Communication Stats","Average Transaction Time"])
+            # Monitor -> Platform Stats - All controllers - enterprises.58399.2.x
+            self.AddOID((0,2,1),return_type = str, description = "CPUTemp", default = "Unknown", keywords = ["Monitor","CPU Temperature"])
+            self.AddOID((0,2,2),return_type = str, description = "PiModel", default = "Unknown", keywords = ["Monitor","Pi Model"])
+            self.AddOID((0,2,3),return_type = str, description = "CPUFreqThrottling", default = "Unknown", keywords = ["Monitor","Pi CPU Frequency Throttling"])
+            self.AddOID((0,2,4),return_type = str, description = "ARMFreqCap", default = "Unknown", keywords = ["Monitor","Pi ARM Frequency Cap"])
+            self.AddOID((0,2,5),return_type = str, description = "ARMUnderVoltage", default = "Unknown", keywords = ["Monitor","Pi Undervoltage"])
+            self.AddOID((0,2,6),return_type = str, description = "CPUUtil", default = "Unknown", keywords = ["Monitor","CPU Utilization"])
+            self.AddOID((0,2,7),return_type = str, description = "OSName", default = "Unknown", keywords = ["Monitor","OS Name"])
+            self.AddOID((0,2,8),return_type = str, description = "OSVersion", default = "Unknown", keywords = ["Monitor","OS Version"])
+            self.AddOID((0,2,9),return_type = str, description = "SysUptime", default = "Unknown", keywords = ["Monitor","System Uptime"])
+            self.AddOID((0,2,10),return_type = str, description = "NetInferface", default = "Unknown", keywords = ["Monitor","Network Interface Used"])
 
             if self.ControllerIsEvolutionNexus() or self.ControllerSelected == "generac_evo_nexus":
                 self.LogDebug("Evo/Nexus")
-                # Status Engine
-                self.AddOID((CtlID,0,0,0),return_type = str, description = "SwitchState", default = "Unknown", keywords = ["Status/Engine","Switch State"])
-                self.AddOID((CtlID,0,0,1),return_type = str, description = "EngineState", default = "Unknown", keywords = ["Status/Engine","Engine State"])
-                self.AddOID((CtlID,0,0,2),return_type = str, description = "ActiveRelays", default = "", keywords = ["Status/Engine","Active Relays"])
-                self.AddOID((CtlID,0,0,3),return_type = str, description = "ActiveSensors", default = "", keywords = ["Status/Engine","Active Sensors"])
-                self.AddOID((CtlID,0,0,4),return_type = str, description = "BatteryVolts", default = "", keywords = ["Status/Engine","Battery Voltage"])
-                self.AddOID((CtlID,0,0,5),return_type = str, description = "BatteryStatus", default = "", keywords = ["Status/Engine","Battery Status"])
-                self.AddOID((CtlID,0,0,6),return_type = str, description = "RPM", default = "", keywords = ["Status/Engine","RPM"])
-                self.AddOID((CtlID,0,0,7),return_type = str, description = "Frequency", default = "", keywords = ["Status/Engine","Frequency"])
-                self.AddOID((CtlID,0,0,8),return_type = str, description = "OutputVoltage", default = "", keywords = ["Status/Engine","Output Voltage"])
-                self.AddOID((CtlID,0,0,9),return_type = str, description = "OutputCurrent", default = "", keywords = ["Status/Engine","Output Current"])
-                self.AddOID((CtlID,0,0,10),return_type = str, description = "OutputPower", default = "", keywords = ["Status/Engine","Output Power"])
-                self.AddOID((CtlID,0,0,11),return_type = str, description = "RotorPoles", default = "", keywords = ["Status/Engine","Rotor Poles"])
-                # Status Line
-                self.AddOID((CtlID,0,1,0),return_type = str, description = "UtilityVoltage", default = "", keywords = ["Status/Line","Utility Voltage"])
-                self.AddOID((CtlID,0,1,1),return_type = str, description = "UtilityVoltageMax", default = "", keywords = ["Status/Line","Utility Max Voltage"])
-                self.AddOID((CtlID,0,1,2),return_type = str, description = "UtilityVoltageMin", default = "", keywords = ["Status/Line","Utility Min Voltage"])
-                self.AddOID((CtlID,0,1,3),return_type = str, description = "UtilityThresholdVoltage", default = "", keywords = ["Status/Line","Utility Threshold Voltage"])
-                self.AddOID((CtlID,0,1,4),return_type = str, description = "UtilityPickupVoltage", default = "", keywords = ["Status/Line","Utility Pickup Voltage"])
-                self.AddOID((CtlID,0,1,4),return_type = str, description = "SetOutputVoltage", default = "", keywords = ["Status/Line","Set Output Voltage"])
-                # Status Last Alarms
-                self.AddOID((CtlID,0,2,0),return_type = str, description = "LastAlarmLog", default = " ", keywords = ["Status","Last Log","Alarm Log"])
-                self.AddOID((CtlID,0,2,1),return_type = str, description = "LastServiceLog", default = " ", keywords = ["Status","Last Log","Service Log"])
-                self.AddOID((CtlID,0,2,2),return_type = str, description = "LastRunLog", default = " ", keywords = ["Status","Last Log","Run Log"])
-                # Status Time
-                self.AddOID((CtlID,0,3,0),return_type = str, description = "MonitorTime", default = " ", keywords = ["Status/Time","Monitor Time"])
-                self.AddOID((CtlID,0,3,1),return_type = str, description = "GeneratorTime", default = " ", keywords = ["Status/Time","Generator Time"])
-
-                #Maintenance
-                self.AddOID((CtlID,1,0,0),return_type = str, description = "GeneratorModel", default = " ", keywords = ["Maintenance","Model"])
-                self.AddOID((CtlID,1,0,1),return_type = str, description = "SerialNumber", default = " ", keywords = ["Maintenance","Generator Serial Number"])
-                self.AddOID((CtlID,1,0,2),return_type = str, description = "Controller", default = " ", keywords = ["Maintenance","Controller Detected"])
-                self.AddOID((CtlID,1,0,3),return_type = str, description = "NominalRPM", default = " ", keywords = ["Maintenance","Nominal RPM"])
-                self.AddOID((CtlID,1,0,4),return_type = str, description = "RatedkW", default = " ", keywords = ["Maintenance","Rated kW"])
-                self.AddOID((CtlID,1,0,5),return_type = str, description = "RatedFreq", default = " ", keywords = ["Maintenance","Nominal Frequency"])
-                self.AddOID((CtlID,1,0,6),return_type = str, description = "FuelType", default = " ", keywords = ["Maintenance","Fuel Type"])
-                self.AddOID((CtlID,1,0,7),return_type = str, description = "FuelLevelSensor", default = " ", keywords = ["Maintenance","Fuel Level Sensor"])
-                self.AddOID((CtlID,1,0,8),return_type = str, description = "EstFuelInTank", default = " ", keywords = ["Maintenance","Estimated Fuel In Tank"])
-                self.AddOID((CtlID,1,0,9),return_type = str, description = "Displacement", default = " ", keywords = ["Maintenance","Engine Displacement"])
-                self.AddOID((CtlID,1,0,10),return_type = str, description = "AmbientTemp", default = " ", keywords = ["Maintenance","Ambient Temperature Sensor"])
-                self.AddOID((CtlID,1,0,11),return_type = str, description = "kwH30", default = " ", keywords = ["Maintenance","kW Hours in last 30 days"])
-                self.AddOID((CtlID,1,0,12),return_type = str, description = "Fuel30", default = " ", keywords = ["Maintenance","Fuel Consumption in last 30 days"])
-                self.AddOID((CtlID,1,0,13),return_type = str, description = "TotalFuelUsed", default = " ", keywords = ["Maintenance","Total Power Log Fuel Consumption"])
-                self.AddOID((CtlID,1,0,14),return_type = str, description = "RunHours30", default = " ", keywords = ["Maintenance","Run Hours in last 30 days"])
-                self.AddOID((CtlID,1,0,15),return_type = str, description = "EstHoursInTank", default = " ", keywords = ["Maintenance","Hours of Fuel Remaining","Estimated"])
-                self.AddOID((CtlID,1,0,16),return_type = str, description = "LoadHoursInTank", default = " ", keywords = ["Maintenance","Hours of Fuel Remaining","Current"])
-                self.AddOID((CtlID,1,0,17),return_type = str, description = "FuelInTank", default = " ", keywords = ["Maintenance","Fuel In Tank (Sensor)"])
-                self.AddOID((CtlID,1,0,18),return_type = str, description = "FuelLevelState", default = " ", keywords = ["Maintenance","Fuel Level State"])
-
-                #Maintenance->Controller Settings
-                self.AddOID((CtlID,1,1,0),return_type = str, description = "CalCurrent1", default = " ", keywords = ["Maintenance/Controller Settings","Calibrate Current 1"])
-                self.AddOID((CtlID,1,1,1),return_type = str, description = "CalCurrent1", default = " ", keywords = ["Maintenance/Controller Settings","Calibrate Current 2"])
-                self.AddOID((CtlID,1,1,2),return_type = str, description = "CalVolts", default = " ", keywords = ["Maintenance/Controller Settings","Calibrate Volts"])
-                self.AddOID((CtlID,1,1,3),return_type = str, description = "NominalLineVolts", default = " ", keywords = ["Maintenance/Controller Settings","Nominal Line Voltage"])
-                self.AddOID((CtlID,1,1,4),return_type = str, description = "RatedMaxPower", default = " ", keywords = ["Maintenance/Controller Settings","Rated Max Power"])
-                self.AddOID((CtlID,1,1,5),return_type = str, description = "ParamGroup", default = " ", keywords = ["Maintenance/Controller Settings","Param Group"])
-                self.AddOID((CtlID,1,1,6),return_type = str, description = "VoltageCode", default = " ", keywords = ["Maintenance/Controller Settings","Voltage Code"])
-                self.AddOID((CtlID,1,1,7),return_type = str, description = "Phase", default = " ", keywords = ["Maintenance/Controller Settings","Phase"])
-                self.AddOID((CtlID,1,1,8),return_type = str, description = "HoursProtection", default = " ", keywords = ["Maintenance/Controller Settings","Hours of Protection"])
-                self.AddOID((CtlID,1,1,9),return_type = str, description = "VoltsPerHz", default = " ", keywords = ["Maintenance/Controller Settings","Volts Per Hertz"])
-                self.AddOID((CtlID,1,1,10),return_type = str, description = "Gain", default = " ", keywords = ["Maintenance/Controller Settings","Gain"])
-                self.AddOID((CtlID,1,1,11),return_type = str, description = "TargetFreq", default = " ", keywords = ["Maintenance/Controller Settings","Target Frequency"])
-                self.AddOID((CtlID,1,1,12),return_type = str, description = "TargetVolts", default = " ", keywords = ["Maintenance/Controller Settings","Target Voltage"])
-                # Maintenance->Exercise
-                self.AddOID((CtlID,1,2,0),return_type = str, description = "ExerciseTime", default = " ", keywords = ["Maintenance/Exercise","Exercise Time"])
-                self.AddOID((CtlID,1,2,1),return_type = str, description = "ExerciseDuration", default = " ", keywords = ["Maintenance/Exercise","Exercise Duration"])
-                #Maintenance->Service
-                self.AddOID((CtlID,1,3,0),return_type = str, description = "AFDue", default = " ", keywords = ["Maintenance/Service","Air Filter Service Due"])
-                self.AddOID((CtlID,1,3,1),return_type = str, description = "OilDue", default = " ", keywords = ["Maintenance/Service","Oil and Oil Filter Service Due"])
-                self.AddOID((CtlID,1,3,2),return_type = str, description = "SPDue", default = " ", keywords = ["Maintenance/Service","Spark Plug Service Due"])
-                self.AddOID((CtlID,1,3,3),return_type = str, description = "BattServiceDue", default = " ", keywords = ["Maintenance/Service","Battery Service Due"])
-                self.AddOID((CtlID,1,3,4),return_type = str, description = "ServiceADue", default = " ", keywords = ["Maintenance/Service","Service A Due"])
-                self.AddOID((CtlID,1,3,5),return_type = str, description = "ServiceBDue", default = " ", keywords = ["Maintenance/Service","Service B Due"])
-                self.AddOID((CtlID,1,3,6),return_type = str, description = "BatteryCheckDue", default = " ", keywords = ["Maintenance/Service","Battery Check Due"])
-                self.AddOID((CtlID,1,3,7),return_type = str, description = "TotalRunHours", default = " ", keywords = ["Maintenance/Service","Total Run Hours"])
-                self.AddOID((CtlID,1,3,8),return_type = str, description = "HardwareVersion", default = " ", keywords = ["Maintenance/Service","Hardware Version"])
-                self.AddOID((CtlID,1,3,9),return_type = str, description = "FirmwareVersion", default = " ", keywords = ["Maintenance/Service","Firmware Version"])
+                # (root branch) - enterprises.58399.1.x
+                # Status        - enterprises.58399.1.0
+                # Status Engine - enterprises.58399.1.0.x
+                self.AddOID((CtlID,0,0,1),return_type = str, description = "switchState", default = "Unknown", keywords = ["Status/Engine","Switch State"])
+                self.AddOID((CtlID,0,0,2),return_type = str, description = "EngineState", default = "Unknown", keywords = ["Status/Engine","Engine State"])
+                self.AddOID((CtlID,0,0,3),return_type = str, description = "activeRelays", default = "", keywords = ["Status/Engine","Active Relays"])
+                self.AddOID((CtlID,0,0,3),return_type = str, description = "activeSensors", default = "", keywords = ["Status/Engine","Active Sensors"])
+                self.AddOID((CtlID,0,0,4),return_type = str, description = "batteryVolts", default = "", keywords = ["Status/Engine","Battery Voltage"])
+                self.AddOID((CtlID,0,0,5),return_type = str, description = "batteryStatus", default = "", keywords = ["Status/Engine","Battery Status"])
+                self.AddOID((CtlID,0,0,6),return_type = str, description = "rpm", default = "", keywords = ["Status/Engine","RPM"])
+                self.AddOID((CtlID,0,0,7),return_type = str, description = "frequency", default = "", keywords = ["Status/Engine","Frequency"])
+                self.AddOID((CtlID,0,0,8),return_type = str, description = "outputVoltage", default = "", keywords = ["Status/Engine","Output Voltage"])
+                self.AddOID((CtlID,0,0,9),return_type = str, description = "outputCurrent", default = "", keywords = ["Status/Engine","Output Current"])
+                self.AddOID((CtlID,0,0,10),return_type = str, description = "outputPower", default = "", keywords = ["Status/Engine","Output Power"])
+                self.AddOID((CtlID,0,0,11),return_type = str, description = "rotorPoles", default = "", keywords = ["Status/Engine","Rotor Poles"])
+                # Status Line - enterprises.58399.1.0.1.x
+                self.AddOID((CtlID,0,1,1),return_type = str, description = "utilityVoltage", default = "", keywords = ["Status/Line","Utility Voltage"])
+                self.AddOID((CtlID,0,1,2),return_type = str, description = "utilityVoltageMax", default = "", keywords = ["Status/Line","Utility Max Voltage"])
+                self.AddOID((CtlID,0,1,3),return_type = str, description = "utilityVoltageMin", default = "", keywords = ["Status/Line","Utility Min Voltage"])
+                self.AddOID((CtlID,0,1,4),return_type = str, description = "utilityThresholdVoltage", default = "", keywords = ["Status/Line","Utility Threshold Voltage"])
+                self.AddOID((CtlID,0,1,5),return_type = str, description = "utilityPickupVoltage", default = "", keywords = ["Status/Line","Utility Pickup Voltage"])
+                self.AddOID((CtlID,0,1,6),return_type = str, description = "setOutputVoltage", default = "", keywords = ["Status/Line","Set Output Voltage"])
+                # Status Last Alarms - enterprises.58399.1.0.2.x
+                self.AddOID((CtlID,0,2,1),return_type = str, description = "lastAlarmLog", default = " ", keywords = ["Status","Last Log","Alarm Log"])
+                self.AddOID((CtlID,0,2,2),return_type = str, description = "lastServiceLog", default = " ", keywords = ["Status","Last Log","Service Log"])
+                self.AddOID((CtlID,0,2,3),return_type = str, description = "lastRunLog", default = " ", keywords = ["Status","Last Log","Run Log"])
+                # Status Time - enterprises.58399.1.0.3.x
+                self.AddOID((CtlID,0,3,1),return_type = str, description = "monitorTime", default = " ", keywords = ["Status/Time","Monitor Time"])
+                self.AddOID((CtlID,0,3,2),return_type = str, description = "generatorTime", default = " ", keywords = ["Status/Time","Generator Time"])
+                #Maintenance - enterprises.58399.1.1.0.x
+                self.AddOID((CtlID,1,0,1),return_type = str, description = "generatorModel", default = " ", keywords = ["Maintenance","Model"])
+                self.AddOID((CtlID,1,0,2),return_type = str, description = "serialNumber", default = " ", keywords = ["Maintenance","Generator Serial Number"])
+                self.AddOID((CtlID,1,0,3),return_type = str, description = "controller", default = " ", keywords = ["Maintenance","Controller Detected"])
+                self.AddOID((CtlID,1,0,4),return_type = str, description = "nominalRPM", default = " ", keywords = ["Maintenance","Nominal RPM"])
+                self.AddOID((CtlID,1,0,5),return_type = str, description = "ratedkW", default = " ", keywords = ["Maintenance","Rated kW"])
+                self.AddOID((CtlID,1,0,6),return_type = str, description = "ratedFreq", default = " ", keywords = ["Maintenance","Nominal Frequency"])
+                self.AddOID((CtlID,1,0,7),return_type = str, description = "fuelType", default = " ", keywords = ["Maintenance","Fuel Type"])
+                self.AddOID((CtlID,1,0,8),return_type = str, description = "fuelLevelSensor", default = " ", keywords = ["Maintenance","Fuel Level Sensor"])
+                self.AddOID((CtlID,1,0,9),return_type = str, description = "estFuelInTank", default = " ", keywords = ["Maintenance","Estimated Fuel In Tank"])
+                self.AddOID((CtlID,1,0,10),return_type = str, description = "displacement", default = " ", keywords = ["Maintenance","Engine Displacement"])
+                self.AddOID((CtlID,1,0,11),return_type = str, description = "ambientTemp", default = " ", keywords = ["Maintenance","Ambient Temperature Sensor"])
+                self.AddOID((CtlID,1,0,12),return_type = str, description = "kwH30", default = " ", keywords = ["Maintenance","kW Hours in last 30 days"])
+                self.AddOID((CtlID,1,0,13),return_type = str, description = "fuel30", default = " ", keywords = ["Maintenance","Fuel Consumption in last 30 days"])
+                self.AddOID((CtlID,1,0,14),return_type = str, description = "totalFuelUsed", default = " ", keywords = ["Maintenance","Total Power Log Fuel Consumption"])
+                self.AddOID((CtlID,1,0,15),return_type = str, description = "runHours30", default = " ", keywords = ["Maintenance","Run Hours in last 30 days"])
+                self.AddOID((CtlID,1,0,16),return_type = str, description = "estHoursInTank", default = " ", keywords = ["Maintenance","Hours of Fuel Remaining","Estimated"])
+                self.AddOID((CtlID,1,0,17),return_type = str, description = "loadHoursInTank", default = " ", keywords = ["Maintenance","Hours of Fuel Remaining","Current"])
+                self.AddOID((CtlID,1,0,18),return_type = str, description = "fuelInTank", default = " ", keywords = ["Maintenance","Fuel In Tank (Sensor)"])
+                self.AddOID((CtlID,1,0,19),return_type = str, description = "fuelLevelState", default = " ", keywords = ["Maintenance","Fuel Level State"])
+                #Maintenance->Controller Settings - enterprises.58399.1.1.1.x
+                self.AddOID((CtlID,1,1,1),return_type = str, description = "calCurrent1", default = " ", keywords = ["Maintenance/Controller Settings","Calibrate Current 1"])
+                self.AddOID((CtlID,1,1,2),return_type = str, description = "calCurrent2", default = " ", keywords = ["Maintenance/Controller Settings","Calibrate Current 2"])
+                self.AddOID((CtlID,1,1,3),return_type = str, description = "calVolts", default = " ", keywords = ["Maintenance/Controller Settings","Calibrate Volts"])
+                self.AddOID((CtlID,1,1,4),return_type = str, description = "nominalLineVolts", default = " ", keywords = ["Maintenance/Controller Settings","Nominal Line Voltage"])
+                self.AddOID((CtlID,1,1,5),return_type = str, description = "ratedMaxPower", default = " ", keywords = ["Maintenance/Controller Settings","Rated Max Power"])
+                self.AddOID((CtlID,1,1,6),return_type = str, description = "paramGroup", default = " ", keywords = ["Maintenance/Controller Settings","Param Group"])
+                self.AddOID((CtlID,1,1,7),return_type = str, description = "voltageCode", default = " ", keywords = ["Maintenance/Controller Settings","Voltage Code"])
+                self.AddOID((CtlID,1,1,8),return_type = str, description = "phase", default = " ", keywords = ["Maintenance/Controller Settings","Phase"])
+                self.AddOID((CtlID,1,1,9),return_type = str, description = "hoursProtection", default = " ", keywords = ["Maintenance/Controller Settings","Hours of Protection"])
+                self.AddOID((CtlID,1,1,10),return_type = str, description = "voltsPerHz", default = " ", keywords = ["Maintenance/Controller Settings","Volts Per Hertz"])
+                self.AddOID((CtlID,1,1,11),return_type = str, description = "gain", default = " ", keywords = ["Maintenance/Controller Settings","Gain"])
+                self.AddOID((CtlID,1,1,12),return_type = str, description = "targetFreq", default = " ", keywords = ["Maintenance/Controller Settings","Target Frequency"])
+                self.AddOID((CtlID,1,1,13),return_type = str, description = "targetVolts", default = " ", keywords = ["Maintenance/Controller Settings","Target Voltage"])
+                # Maintenance->Exercise - enterprises.58399.1.1.2.x
+                self.AddOID((CtlID,1,2,1),return_type = str, description = "ExerciseTime", default = " ", keywords = ["Maintenance/Exercise","Exercise Time"])
+                self.AddOID((CtlID,1,2,2),return_type = str, description = "ExerciseDuration", default = " ", keywords = ["Maintenance/Exercise","Exercise Duration"])
+                #Maintenance->Service - enterprises.58399.1.1.3.x
+                self.AddOID((CtlID,1,3,1),return_type = str, description = "AFDue", default = " ", keywords = ["Maintenance/Service","Air Filter Service Due"])
+                self.AddOID((CtlID,1,3,2),return_type = str, description = "OilDue", default = " ", keywords = ["Maintenance/Service","Oil and Oil Filter Service Due"])
+                self.AddOID((CtlID,1,3,3),return_type = str, description = "SPDue", default = " ", keywords = ["Maintenance/Service","Spark Plug Service Due"])
+                self.AddOID((CtlID,1,3,4),return_type = str, description = "BattServiceDue", default = " ", keywords = ["Maintenance/Service","Battery Service Due"])
+                self.AddOID((CtlID,1,3,5),return_type = str, description = "ServiceADue", default = " ", keywords = ["Maintenance/Service","Service A Due"])
+                self.AddOID((CtlID,1,3,6),return_type = str, description = "ServiceBDue", default = " ", keywords = ["Maintenance/Service","Service B Due"])
+                self.AddOID((CtlID,1,3,7),return_type = str, description = "BatteryCheckDue", default = " ", keywords = ["Maintenance/Service","Battery Check Due"])
+                self.AddOID((CtlID,1,3,8),return_type = str, description = "TotalRunHours", default = " ", keywords = ["Maintenance/Service","Total Run Hours"])
+                self.AddOID((CtlID,1,3,9),return_type = str, description = "HardwareVersion", default = " ", keywords = ["Maintenance/Service","Hardware Version"])
+                self.AddOID((CtlID,1,3,10),return_type = str, description = "FirmwareVersion", default = " ", keywords = ["Maintenance/Service","Firmware Version"])
 
             elif self.ControllerIsGeneracH100() or self.ControllerSelected == "h_100":
                 self.LogDebug("H-100/GPanel")
-                # Engine
-                self.AddOID((CtlID,0,0,0),return_type = str, description = "SwitchState", default = " ", keywords = ["Status/Engine","Switch State"])
-                self.AddOID((CtlID,0,0,1),return_type = str, description = "EngineStatus", default = " ", keywords = ["Status/Engine","Engine State"])
-                self.AddOID((CtlID,0,0,2),return_type = str, description = "GeneratorStatus", default = " ", keywords = ["Status/Engine","Generator Status"])
-                self.AddOID((CtlID,0,0,3),return_type = str, description = "OutputPower", default = " ", keywords = ["Status/Engine","Output Power"])
-                self.AddOID((CtlID,0,0,4),return_type = str, description = "OutputPowerFactor", default = " ", keywords = ["Status/Engine","Power Factor"])
-                self.AddOID((CtlID,0,0,5),return_type = str, description = "RPM", default = 0, keywords = ["Status/Engine/RPM"])
-                self.AddOID((CtlID,0,0,6),return_type = str, description = "Frequency", default = " ", keywords = ["Status/Engine/Frequency"])
-                self.AddOID((CtlID,0,0,7),return_type = str, description = "ThrottlePosition", default = " ", keywords = ["Status/Engine","Throttle Position"])
-                self.AddOID((CtlID,0,0,8),return_type = str, description = "CoolantTemp", default = " ", keywords = ["Status/Engine","Coolant Temp"])
-                self.AddOID((CtlID,0,0,9),return_type = str, description = "CoolantLevel", default = " ", keywords = ["Status/Engine","Coolant Level"])
-                self.AddOID((CtlID,0,0,10),return_type = str, description = "OilPressure", default = " ", keywords = ["Status/Engine","Oil Pressure"])
-                self.AddOID((CtlID,0,0,11),return_type = str, description = "OilTemp", default = " ", keywords = ["Status/Engine","Oil Temp"])
-                self.AddOID((CtlID,0,0,12),return_type = str, description = "FuelLevel", default = " ", keywords = ["Status/Engine","Fuel Level"])
-                self.AddOID((CtlID,0,0,13),return_type = str, description = "OxygeSensor", default = " ", keywords = ["Status/Engine","Oxygen Sensor"])
-                self.AddOID((CtlID,0,0,14),return_type = str, description = "CurrentPhaseA", default = " ", keywords = ["Status/Engine","Current Phase A"])
-                self.AddOID((CtlID,0,0,15),return_type = str, description = "CurrentPhaseB", default = " ", keywords = ["Status/Engine","Current Phase B"])
-                self.AddOID((CtlID,0,0,16),return_type = str, description = "CurrentPhaseC", default = " ", keywords = ["Status/Engine","Current Phase C"])
-                self.AddOID((CtlID,0,0,17),return_type = str, description = "AvgCurrent", default = " ", keywords = ["Status/Engine","Average Current"])
-                self.AddOID((CtlID,0,0,18),return_type = str, description = "VoltageAB", default = " ", keywords = ["Status/Engine","Voltage A-B"])
-                self.AddOID((CtlID,0,0,19),return_type = str, description = "VoltageBC", default = " ", keywords = ["Status/Engine","Voltage B-C"])
-                self.AddOID((CtlID,0,0,20),return_type = str, description = "VoltageCA", default = " ", keywords = ["Status/Engine","Voltage C-A"])
-                self.AddOID((CtlID,0,0,21),return_type = str, description = "AvgVoltage", default = " ", keywords = ["Status/Engine","Average Voltage"])
-                self.AddOID((CtlID,0,0,22),return_type = str, description = "AirFuelDutyCycle", default = " ", keywords = ["Status/Engine","Air Fuel Duty Cycle" ])
-                # Alarms
-                self.AddOID((CtlID,0,1,0),return_type = str, description = "ActiveAlarms", default = " ", keywords = ["Status/Alarms","Number of Active Alarms"])
-                self.AddOID((CtlID,0,1,1),return_type = str, description = "AckAlarms", default = " ", keywords = ["Status/Alarms","Number of Acknowledged Alarms"])
-                self.AddOID((CtlID,0,1,2),return_type = str, description = "AlarmList", default = " ", keywords = ["Status/Alarms","Alarm List"])
-
-                # Battery
-                self.AddOID((CtlID,0,2,0),return_type = str, description = "BatteryVoltage", default = " ", keywords = ["Status/Battery","Battery Voltage"])
-                self.AddOID((CtlID,0,2,1),return_type = str, description = "BatteryCurrent", default = " ", keywords = ["Status/Battery","Battery Charger Current"])
-                # Line State
-                self.AddOID((CtlID,0,4,0),return_type = str, description = "TransferSwitchState", default = " ", keywords = ["Status/Line State","Transfer Switch State"])
+                #root OID: enterprises.58399.2
+                # Status - enterprises.58399.2.0
+                # Engine - enterprises.58399.2.0.0.x
+                self.AddOID((CtlID,0,0,1),return_type = str, description = "SwitchState", default = " ", keywords = ["Status/Engine","Switch State"])
+                self.AddOID((CtlID,0,0,2),return_type = str, description = "EngineStatus", default = " ", keywords = ["Status/Engine","Engine State"])
+                self.AddOID((CtlID,0,0,3),return_type = str, description = "GeneratorStatus", default = " ", keywords = ["Status/Engine","Generator Status"])
+                self.AddOID((CtlID,0,0,4),return_type = str, description = "OutputPower", default = " ", keywords = ["Status/Engine","Output Power"])
+                self.AddOID((CtlID,0,0,5),return_type = str, description = "OutputPowerFactor", default = " ", keywords = ["Status/Engine","Power Factor"])
+                self.AddOID((CtlID,0,0,6),return_type = str, description = "RPM", default = 0, keywords = ["Status/Engine/RPM"])
+                self.AddOID((CtlID,0,0,7),return_type = str, description = "Frequency", default = " ", keywords = ["Status/Engine/Frequency"])
+                self.AddOID((CtlID,0,0,8),return_type = str, description = "ThrottlePosition", default = " ", keywords = ["Status/Engine","Throttle Position"])
+                self.AddOID((CtlID,0,0,9),return_type = str, description = "CoolantTemp", default = " ", keywords = ["Status/Engine","Coolant Temp"])
+                self.AddOID((CtlID,0,0,10),return_type = str, description = "CoolantLevel", default = " ", keywords = ["Status/Engine","Coolant Level"])
+                self.AddOID((CtlID,0,0,11),return_type = str, description = "OilPressure", default = " ", keywords = ["Status/Engine","Oil Pressure"])
+                self.AddOID((CtlID,0,0,12),return_type = str, description = "OilTemp", default = " ", keywords = ["Status/Engine","Oil Temp"])
+                self.AddOID((CtlID,0,0,13),return_type = str, description = "FuelLevel", default = " ", keywords = ["Status/Engine","Fuel Level"])
+                self.AddOID((CtlID,0,0,14),return_type = str, description = "OxygeSensor", default = " ", keywords = ["Status/Engine","Oxygen Sensor"])
+                self.AddOID((CtlID,0,0,15),return_type = str, description = "CurrentPhaseA", default = " ", keywords = ["Status/Engine","Current Phase A"])
+                self.AddOID((CtlID,0,0,16),return_type = str, description = "CurrentPhaseB", default = " ", keywords = ["Status/Engine","Current Phase B"])
+                self.AddOID((CtlID,0,0,17),return_type = str, description = "CurrentPhaseC", default = " ", keywords = ["Status/Engine","Current Phase C"])
+                self.AddOID((CtlID,0,0,18),return_type = str, description = "AvgCurrent", default = " ", keywords = ["Status/Engine","Average Current"])
+                self.AddOID((CtlID,0,0,19),return_type = str, description = "VoltageAB", default = " ", keywords = ["Status/Engine","Voltage A-B"])
+                self.AddOID((CtlID,0,0,20),return_type = str, description = "VoltageBC", default = " ", keywords = ["Status/Engine","Voltage B-C"])
+                self.AddOID((CtlID,0,0,21),return_type = str, description = "VoltageCA", default = " ", keywords = ["Status/Engine","Voltage C-A"])
+                self.AddOID((CtlID,0,0,22),return_type = str, description = "AvgVoltage", default = " ", keywords = ["Status/Engine","Average Voltage"])
+                self.AddOID((CtlID,0,0,23),return_type = str, description = "AirFuelDutyCycle", default = " ", keywords = ["Status/Engine","Air Fuel Duty Cycle" ])
+                # Alarms - enterprises.58399.2.0.1.x
+                self.AddOID((CtlID,0,1,1),return_type = str, description = "ActiveAlarms", default = " ", keywords = ["Status/Alarms","Number of Active Alarms"])
+                self.AddOID((CtlID,0,1,2),return_type = str, description = "AckAlarms", default = " ", keywords = ["Status/Alarms","Number of Acknowledged Alarms"])
+                self.AddOID((CtlID,0,1,3),return_type = str, description = "AlarmList", default = " ", keywords = ["Status/Alarms","Alarm List"])
+                # Battery - enterprises.58399.2.0.2.x
+                self.AddOID((CtlID,0,2,1),return_type = str, description = "BatteryVoltage", default = " ", keywords = ["Status/Battery","Battery Voltage"])
+                self.AddOID((CtlID,0,2,2),return_type = str, description = "BatteryCurrent", default = " ", keywords = ["Status/Battery","Battery Charger Current"])
+                # Status Time - enterprises.58399.2.0.3.x
+                self.AddOID((CtlID,0,3,1),return_type = str, description = "MonitorTime", default = " ", keywords = ["Status/Time","Monitor Time"])
+                self.AddOID((CtlID,0,3,2),return_type = str, description = "GeneratorTime", default = " ", keywords = ["Status/Time","Generator Time"])
+                # Line State - enterprises.58399.2.0.4.x
+                self.AddOID((CtlID,0,4,1),return_type = str, description = "TransferSwitchState", default = " ", keywords = ["Status/Line State","Transfer Switch State"])
                 # TODO add HTS switch info
-                # Status Time
-                self.AddOID((CtlID,0,3,0),return_type = str, description = "MonitorTime", default = " ", keywords = ["Status/Time","Monitor Time"])
-                self.AddOID((CtlID,0,3,1),return_type = str, description = "GeneratorTime", default = " ", keywords = ["Status/Time","Generator Time"])
                 # TODO selected H-100 Maint items?
+                
             elif self.ControllerIsGeneracPowerZone() or self.ControllerSelected == "powerzone":
-                self.LogDebug("H-100/GPanel")
-                # Engine
-                self.AddOID((CtlID,0,0,0),return_type = str, description = "SwitchState", default = " ", keywords = ["Status/Engine","Switch State"])
-                self.AddOID((CtlID,0,0,1),return_type = str, description = "EngineStatus", default = " ", keywords = ["Status/Engine","Engine State"])
-                self.AddOID((CtlID,0,0,2),return_type = str, description = "GeneratorStatus", default = " ", keywords = ["Status/Engine","Generator Status"])
-                self.AddOID((CtlID,0,0,3),return_type = str, description = "OutputPower", default = " ", keywords = ["Status/Engine","Output Power"])
-                self.AddOID((CtlID,0,0,4),return_type = str, description = "OutputPowerFactor", default = " ", keywords = ["Status/Engine","Power Factor"])
-                self.AddOID((CtlID,0,0,5),return_type = str, description = "RPM", default = 0, keywords = ["Status/Engine/RPM"])
-                self.AddOID((CtlID,0,0,6),return_type = str, description = "Frequency", default = " ", keywords = ["Status/Engine/Frequency"])
-                self.AddOID((CtlID,0,0,7),return_type = str, description = "ThrottlePosition", default = " ", keywords = ["Status/Engine","Throttle Position"])
-                self.AddOID((CtlID,0,0,8),return_type = str, description = "CoolantTemp", default = " ", keywords = ["Status/Engine","Coolant Temp"])
-                self.AddOID((CtlID,0,0,9),return_type = str, description = "CoolantLevel", default = " ", keywords = ["Status/Engine","Coolant Level"])
-                self.AddOID((CtlID,0,0,10),return_type = str, description = "OilPressure", default = " ", keywords = ["Status/Engine","Oil Pressure"])
-                self.AddOID((CtlID,0,0,11),return_type = str, description = "OilTemp", default = " ", keywords = ["Status/Engine","Oil Temp"])
-                self.AddOID((CtlID,0,0,12),return_type = str, description = "FuelLevel", default = " ", keywords = ["Status/Engine","Fuel Level"])
-                self.AddOID((CtlID,0,0,13),return_type = str, description = "OxygeSensor", default = " ", keywords = ["Status/Engine","Oxygen Sensor"])
-                self.AddOID((CtlID,0,0,14),return_type = str, description = "CurrentPhaseA", default = " ", keywords = ["Status/Engine","Current Phase A"])
-                self.AddOID((CtlID,0,0,15),return_type = str, description = "CurrentPhaseB", default = " ", keywords = ["Status/Engine","Current Phase B"])
-                self.AddOID((CtlID,0,0,16),return_type = str, description = "CurrentPhaseC", default = " ", keywords = ["Status/Engine","Current Phase C"])
-                self.AddOID((CtlID,0,0,17),return_type = str, description = "AvgCurrent", default = " ", keywords = ["Status/Engine","Average Current"])
-                self.AddOID((CtlID,0,0,18),return_type = str, description = "VoltageAB", default = " ", keywords = ["Status/Engine","Voltage A-B"])
-                self.AddOID((CtlID,0,0,19),return_type = str, description = "VoltageBC", default = " ", keywords = ["Status/Engine","Voltage B-C"])
-                self.AddOID((CtlID,0,0,20),return_type = str, description = "VoltageCA", default = " ", keywords = ["Status/Engine","Voltage C-A"])
-                self.AddOID((CtlID,0,0,21),return_type = str, description = "AvgVoltage", default = " ", keywords = ["Status/Engine","Average Voltage"])
-                self.AddOID((CtlID,0,0,22),return_type = str, description = "AirFuelDutyCycle", default = " ", keywords = ["Status/Engine","Air Fuel Duty Cycle" ])
-                # Alarms
-                self.AddOID((CtlID,0,1,2),return_type = str, description = "AlarmList", default = " ", keywords = ["Status/Alarms","Alarm List"])
-
-                # Battery
-                self.AddOID((CtlID,0,2,0),return_type = str, description = "BatteryVoltage", default = " ", keywords = ["Status/Battery","Battery Voltage"])
-                self.AddOID((CtlID,0,2,1),return_type = str, description = "BatteryCurrent", default = " ", keywords = ["Status/Battery","Battery Charger Current"])
-
-                # TODO add HTS switch info
-                # Status Time
-                self.AddOID((CtlID,0,3,0),return_type = str, description = "MonitorTime", default = " ", keywords = ["Status/Time","Monitor Time"])
-                self.AddOID((CtlID,0,3,1),return_type = str, description = "GeneratorTime", default = " ", keywords = ["Status/Time","Generator Time"])
-            # Monitor->Generator Monitor Stats
-            self.AddOID((CtlID,4,0,0),return_type = str, description = "MonitorHealth", default = "Unknown", keywords = ["Monitor","Monitor Health"])
-            self.AddOID((CtlID,4,0,1),return_type = str, description = "RunTime", default = "Unknown", keywords = ["Monitor","Run time"])
-            self.AddOID((CtlID,4,0,2),return_type = str, description = "PowerLogSize", default = "", keywords = ["Monitor","Power log file size"])
-            self.AddOID((CtlID,4,0,3),return_type = str, description = "Version", default = "", keywords = ["Monitor","Generator Monitor Version"])
-            # Communication Stats
-            self.AddOID((CtlID,4,1,0),return_type = str, description = "PacketCount", default = "Unknown", keywords = ["Monitor/Communication Stats","Packet Count"])
-            self.AddOID((CtlID,4,1,1),return_type = str, description = "CRCErrors", default = "Unknown", keywords = ["Monitor/Communication Stats","CRC Errors"])
-            self.AddOID((CtlID,4,1,2),return_type = str, description = "CRCPercent", default = "Unknown", keywords = ["Monitor/Communication Stats","CRC Percent Errors"])
-            self.AddOID((CtlID,4,1,3),return_type = str, description = "PacketTimeouts", default = "Unknown", keywords = ["Monitor/Communication Stats","Timeout Errors"])
-            self.AddOID((CtlID,4,1,4),return_type = str, description = "TimeoutPercent", default = "Unknown", keywords = ["Monitor/Communication Stats","Timeout Percent Errors"])
-            self.AddOID((CtlID,4,1,5),return_type = str, description = "ModbusErrors", default = "Unknown", keywords = ["Monitor/Communication Stats","Modbus Exceptions"])
-            self.AddOID((CtlID,4,1,6),return_type = str, description = "ValidationErrors", default = "Unknown", keywords = ["Monitor/Communication Stats","Validation Errors"])
-            self.AddOID((CtlID,4,1,7),return_type = str, description = "InvalidData", default = "Unknown", keywords = ["Monitor/Communication Stats","Invalid Data"])
-            self.AddOID((CtlID,4,1,8),return_type = str, description = "DiscardedBytes", default = "Unknown", keywords = ["Monitor/Communication Stats","Discarded Bytes"])
-            self.AddOID((CtlID,4,1,9),return_type = str, description = "CommRestarts", default = "Unknown", keywords = ["Monitor/Communication Stats","Comm Restarts"])
-            self.AddOID((CtlID,4,1,10),return_type = str, description = "PPS", default = "Unknown", keywords = ["Monitor/Communication Stats","Packets Per Second"])
-            self.AddOID((CtlID,4,1,11),return_type = str, description = "AvgTransTime", default = "Unknown", keywords = ["Monitor/Communication Stats","Average Transaction Time"])
-
-            # Monitor -> Platform Stats
-            self.AddOID((CtlID,4,2,0),return_type = str, description = "CPUTemp", default = "Unknown", keywords = ["Monitor","CPU Temperature"])
-            self.AddOID((CtlID,4,2,1),return_type = str, description = "PiModel", default = "Unknown", keywords = ["Monitor","Pi Model"])
-            self.AddOID((CtlID,4,2,2),return_type = str, description = "CPUFreqThrottling", default = "Unknown", keywords = ["Monitor","Pi CPU Frequency Throttling"])
-            self.AddOID((CtlID,4,2,3),return_type = str, description = "ARMFreqCap", default = "Unknown", keywords = ["Monitor","Pi ARM Frequency Cap"])
-            self.AddOID((CtlID,4,2,4),return_type = str, description = "ARMUnderVoltage", default = "Unknown", keywords = ["Monitor","Pi Undervoltage"])
-            self.AddOID((CtlID,4,2,5),return_type = str, description = "CPUUtil", default = "Unknown", keywords = ["Monitor","CPU Utilization"])
-            self.AddOID((CtlID,4,2,6),return_type = str, description = "OSName", default = "Unknown", keywords = ["Monitor","OS Name"])
-            self.AddOID((CtlID,4,2,7),return_type = str, description = "OSVersion", default = "Unknown", keywords = ["Monitor","OS Version"])
-            self.AddOID((CtlID,4,2,8),return_type = str, description = "SysUptime", default = "Unknown", keywords = ["Monitor","System Uptime"])
-            self.AddOID((CtlID,4,2,9),return_type = str, description = "NetInferface", default = "Unknown", keywords = ["Monitor","Network Interface Used"])
+                self.LogDebug("PowerZone")
+                #root            enterprises.58399.2
+                #Status          enterprises.58399.2.0
+                #Status Engine - enterprises.58399.2.0.0.x
+                self.AddOID((CtlID,0,0,1),return_type = str, description = "SwitchState", default = " ", keywords = ["Status/Engine","Switch State"])
+                self.AddOID((CtlID,0,0,2),return_type = str, description = "EngineStatus", default = " ", keywords = ["Status/Engine","Engine State"])
+                self.AddOID((CtlID,0,0,3),return_type = str, description = "GeneratorStatus", default = " ", keywords = ["Status/Engine","Generator Status"])
+                self.AddOID((CtlID,0,0,4),return_type = str, description = "OutputPower", default = " ", keywords = ["Status/Engine","Output Power"])
+                self.AddOID((CtlID,0,0,5),return_type = str, description = "OutputPowerFactor", default = " ", keywords = ["Status/Engine","Power Factor"])
+                self.AddOID((CtlID,0,0,6),return_type = str, description = "RPM", default = 0, keywords = ["Status/Engine/RPM"])
+                self.AddOID((CtlID,0,0,7),return_type = str, description = "Frequency", default = " ", keywords = ["Status/Engine/Frequency"])
+                self.AddOID((CtlID,0,0,8),return_type = str, description = "ThrottlePosition", default = " ", keywords = ["Status/Engine","Throttle Position"])
+                self.AddOID((CtlID,0,0,9),return_type = str, description = "CoolantTemp", default = " ", keywords = ["Status/Engine","Coolant Temp"])
+                self.AddOID((CtlID,0,0,10),return_type = str, description = "CoolantLevel", default = " ", keywords = ["Status/Engine","Coolant Level"])
+                self.AddOID((CtlID,0,0,11),return_type = str, description = "OilPressure", default = " ", keywords = ["Status/Engine","Oil Pressure"])
+                self.AddOID((CtlID,0,0,12),return_type = str, description = "OilTemp", default = " ", keywords = ["Status/Engine","Oil Temp"])
+                self.AddOID((CtlID,0,0,13),return_type = str, description = "FuelLevel", default = " ", keywords = ["Status/Engine","Fuel Level"])
+                self.AddOID((CtlID,0,0,14),return_type = str, description = "OxygeSensor", default = " ", keywords = ["Status/Engine","Oxygen Sensor"])
+                self.AddOID((CtlID,0,0,15),return_type = str, description = "CurrentPhaseA", default = " ", keywords = ["Status/Engine","Current Phase A"])
+                self.AddOID((CtlID,0,0,16),return_type = str, description = "CurrentPhaseB", default = " ", keywords = ["Status/Engine","Current Phase B"])
+                self.AddOID((CtlID,0,0,17),return_type = str, description = "CurrentPhaseC", default = " ", keywords = ["Status/Engine","Current Phase C"])
+                self.AddOID((CtlID,0,0,18),return_type = str, description = "AvgCurrent", default = " ", keywords = ["Status/Engine","Average Current"])
+                self.AddOID((CtlID,0,0,19),return_type = str, description = "VoltageAB", default = " ", keywords = ["Status/Engine","Voltage A-B"])
+                self.AddOID((CtlID,0,0,20),return_type = str, description = "VoltageBC", default = " ", keywords = ["Status/Engine","Voltage B-C"])
+                self.AddOID((CtlID,0,0,21),return_type = str, description = "VoltageCA", default = " ", keywords = ["Status/Engine","Voltage C-A"])
+                self.AddOID((CtlID,0,0,22),return_type = str, description = "AvgVoltage", default = " ", keywords = ["Status/Engine","Average Voltage"])
+                self.AddOID((CtlID,0,0,23),return_type = str, description = "AirFuelDutyCycle", default = " ", keywords = ["Status/Engine","Air Fuel Duty Cycle" ])
+                # Alarms - enterprises.58399.2.0.1.x
+                self.AddOID((CtlID,0,1,1),return_type = str, description = "AlarmList", default = " ", keywords = ["Status/Alarms","Alarm List"])
+                # Battery - enterprises.58399.2.0.2.x
+                self.AddOID((CtlID,0,2,1),return_type = str, description = "BatteryVoltage", default = " ", keywords = ["Status/Battery","Battery Voltage"])
+                self.AddOID((CtlID,0,2,2),return_type = str, description = "BatteryCurrent", default = " ", keywords = ["Status/Battery","Battery Charger Current"])
+                # Status Time - enterprises.58399.2.0.3.x
+                self.AddOID((CtlID,0,3,1),return_type = str, description = "MonitorTime", default = " ", keywords = ["Status/Time","Monitor Time"])
+                self.AddOID((CtlID,0,3,2),return_type = str, description = "GeneratorTime", default = " ", keywords = ["Status/Time","Generator Time"])
+                #TODO Add HTS switch info
 
             self.mibDataIdx = {}
             for mibVar in self.mibData:


### PR DESCRIPTION
##Description

This PR includes changes and files necessary for GenMon's SNMP implementation to pass SMIv2 compliance with respect to OID structure and leaf node layout.  The included MIB file is also SMIv2 compliant and references the new OIDs contained in ths PR.  Beyond OID reorganization and the Enterprise ID, gensnmp.py is otherwise "original" to the last release branch at jgyates/master.
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # issue 652 and provides an SMIv2 compliant MIB

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I used my own genmon installation attached to a Evolution controller to develop and test the OIDs as defined in this MIB.  Changes were then copied from the testing unit and added to my repo. While I've made every attempt to ensure that my changes do not break H100 or PowerZone SNMP implementations, I can't test those controllers on my own.

* Firmware version: 1.18.4(GenMon) 1.13 (Evolution 2.0 controller)
* Hardware: Evolution 2.0 Controller (HW Ver 1.01)  on a Guarding 24kW air cooled generator. 

## Checklist:

- [N/A] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [X] I have reasonably commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested any python code on 3.x
- [N/A] I have tested any javascript on most popular browsers for compatibility
