### PR TITLE
Don't show estimated levels for propane tanks w/sensors

### DIFF
--- a/genmonlib/generac_evolution.py
+++ b/genmonlib/generac_evolution.py
@@ -1929,9 +1929,12 @@ class Evolution(GeneratorController):
                 if FuelValue != None:
                     Maintenance["Maintenance"].append({"Fuel In Tank (Sensor)" : self.ValueOut(FuelValue, Units, JSONNum)})
 
-            if self.FuelTankCalculationSupported():
+            # Don't Show estimated fuel for propane tanks with a sensor on Evo controllers
+            if self.FuelTankCalculationSupported() and not (self.FuelType == "Propane" and (self.ExternalFuelDataSupported() or self.FuelSensorSupported())):
                 Maintenance["Maintenance"].append({"Estimated Fuel In Tank " : self.ValueOut(self.GetEstimatedFuelInTank(ReturnFloat = True), Units, JSONNum)})
 
+            # Show hours of fuel remaining if any calculation is supported 
+            if self.FuelTankCalculationSupported() or self.ExternalFuelDataSupported() or self.FuelSensorSupported():
                 DisplayText = "Hours of Fuel Remaining (Estimated %.02f Load )" % self.EstimateLoad
                 RemainingFuelTimeFloat = self.GetRemainingFuelTime(ReturnFloat = True)
                 if RemainingFuelTimeFloat != None:


### PR DESCRIPTION
# Pull Request Template

## Description

Propane tanks are never filled to 100% and refills are anywhere from 80-85% of total tank size, so tank monitoring utilities and sensors never represent 100% filled. So hide the Estimated value (which assumes full = 100%) whenever a more accurate value is available.

Fixes #662 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested with my current installation of genmon 

**Test Configuration**:
* Firmware version: V1.11
* Hardware: Generac Home Guardian 22kW - G0070422 w/Evo 2 controller

## Checklist:

- [x] My code follows the existing code style and formatting of this project
- [x] I have performed a self-review of my own code
- [x] I have reasonably commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested any python code on 3.x
