### PR TITLE
External CT - reduce SPI frequency for noise

### DIFF
--- a/gencthat.py
+++ b/gencthat.py
@@ -48,7 +48,7 @@ class MCP3008(MyCommon):
         try:
             self.spi = SpiDev()
             self.open()
-            self.spi.max_speed_hz = 1000000 # 1MHz
+            self.spi.max_speed_hz = 250000 # 250kHz
         except Exception as e1:
             self.LogErrorLine("Error in MPC308 init: " + str(e1))
             self.FatalError( "Error on opening SPI device: enable SPI or install CT HAT")
@@ -58,7 +58,7 @@ class MCP3008(MyCommon):
 
         try:
             self.spi.open(self.bus, self.device)
-            self.spi.max_speed_hz = 1000000 # 1MHz
+            self.spi.max_speed_hz = 250000 # 250kHz
         except Exception as e1:
             self.LogErrorLine("Error in MPC308 open: " + str(e1))
 

--- a/genmonlib/custom_controller.py
+++ b/genmonlib/custom_controller.py
@@ -1097,7 +1097,7 @@ class CustomController(GeneratorController):
 
             # This assumes the following format:
             # NOTE: all fields are optional
-            # { "strict" : True or False (true requires and outage to use the data)
+            # { "strict" : True or False (true requires an outage to use the data)
             #   "current" : float value in amps
             #   "power"   : float value in kW
             #   "powerfactor" : float value (default is 1.0) used if converting from current to power or power to current


### PR DESCRIPTION
# Pull Request Template

## Description

Reducing the frequency on the MCP3008 chip to help reduce noise.  Also saw a typo in a code comment.

Fixes # (issue)

Helps with issue #645

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] viewed CT data displayed in GenMon over a period of time, observed less drift from the known load value.

**Test Configuration**:
* Firmware version: no generator attached
* Hardware: PintSize.Me Sensor HAT with 2 CTs installed, one on hot one on neutral of same load.

## Checklist:

- [N/A] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [X] I have reasonably commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested any python code on 3.x
- [N/A] I have tested any javascript on most popular browsers for compatibility
