### PR TITLE
Fix E-mail bodies in python3 via SMTP

### DIFF
--- a/genmonlib/mymail.py
+++ b/genmonlib/mymail.py
@@ -177,7 +177,7 @@ class MyMail(MySupport):
         if sys.version_info[0] < 3: #PYTHON 2
             msg.attach(MIMEText(body, 'plain'))
         else:                       #PYTHON 3
-            msg.attach(MIMEText(body, 'plain', _charset='utf-8'), policy=email.policy.SMTP)
+            msg.attach(MIMEText(body, 'plain', _charset='utf-8', policy=email.policy.SMTP))
 
         try:
             if use_ssl:

--- a/genmonlib/mymail.py
+++ b/genmonlib/mymail.py
@@ -148,7 +148,12 @@ class MyMail(MySupport):
         # update time
         tmstamp=datetime.datetime.now().strftime('%I:%M:%S %p')
 
-        msg = MIMEMultipart()
+        if sys.version_info[0] < 3: #PYTHON 2
+            msg = MIMEMultipart()
+        else: # PYTHON 3
+            import email.policy
+            msg = MIMEMultipart(policy=email.policy.SMTP)
+            
         if sender_name == None or not len(sender_name):
             msg['From'] = "<" + sender_account + ">"
         else:
@@ -172,7 +177,7 @@ class MyMail(MySupport):
         if sys.version_info[0] < 3: #PYTHON 2
             msg.attach(MIMEText(body, 'plain'))
         else:                       #PYTHON 3
-            msg.attach(MIMEText(body, 'plain', _charset='utf-8'))
+            msg.attach(MIMEText(body, 'plain', _charset='utf-8'), policy=email.policy.SMTP)
 
         try:
             if use_ssl:
@@ -443,7 +448,11 @@ class MyMail(MySupport):
         # update time
         tmstamp=datetime.datetime.now().strftime('%I:%M:%S %p')
 
-        msg = MIMEMultipart()
+        if sys.version_info[0] < 3: #PYTHON 2
+            msg = MIMEMultipart()
+        else:
+            import email.policy
+            msg = MIMEMultipart(policy=email.policy.SMTP)
         if self.SenderName == None or not len(self.SenderName):
             msg['From'] = "<" + self.SenderAccount + ">"
         else:
@@ -470,7 +479,7 @@ class MyMail(MySupport):
         if sys.version_info[0] < 3: #PYTHON 2
             msg.attach(MIMEText(body, 'plain'))
         else:                       #PYTHON 3
-            msg.attach(MIMEText(body, 'plain', _charset='utf-8'))
+            msg.attach(MIMEText(body, 'plain', _charset='utf-8', policy=email.policy.SMTP))
 
 
         # if the files are not found then we skip them but still send the email


### PR DESCRIPTION
Fixes email bodies being sent directly via SMTP and conforms to RFC standards.

# Pull Request Template

## Description

Fixes #726 when sending messages via SMTP


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested Locally on latest commit of genmon. 

## Checklist:

- [x] Are any new libraries required and have they been added to the install scripts
- [x] My code follows the existing code style and formatting of this project
- [x] I have performed a self-review of my own code
- [x] I have reasonably commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested any python code on 3.x
- [x] I have tested any javascript on most popular browsers for compatibility
