### PR TITLE
Fix genmonmaint.sh no prompt prompting anyway

### DIFF
--- a/genmonmaint.sh
+++ b/genmonmaint.sh
@@ -175,7 +175,7 @@ function installgenmon() {
     sudo chmod 775 "$genmondir/genmonmaint.sh"
     installrpirtscts
 
-    if [ -z "$2" ] || [ $1 == "prompt" ]; then    # Is parameter #1 zero length?
+    if [ -z "$2" ] && [ $1 != "noprompt" ]; then    # Is parameter #1 zero length?
         read -p "Copy configuration files to $config_path? (y/n)?" choice
         case "$choice" in
           y|Y ) echo "Copying *.conf files to "$config_path""
@@ -190,7 +190,7 @@ function installgenmon() {
     else
         copyconffiles
     fi
-    if [ -z "$2" ] || [ $1 == "prompt" ]; then    # Is parameter #1 zero length?
+    if [ -z "$2" ] && [ $1 != "noprompt" ]; then    # Is parameter #1 zero length?
       read -p "Setup the raspberry pi onboard serial port? (y/n)?" choice
       case "$choice" in
         y|Y ) echo "Setting up serial port..."


### PR DESCRIPTION
# Pull Request Template

## Description

Fixing -n argument on genmonmaint.sh. When using `-i -n` the script still prompts the user for yes/no on copying config files and setting up the onboard serial port.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Without changes, run `./genmonmaint.sh -i -n` and observe that you are prompted to copy config files and setup the onboard serial port.
- [X] With changes run `./genmonmaint.sh -i -n` and observe that you are not prompted to copy config files or setup the onboard serial port.  Both happen as if the user selected yes.

**Test Configuration**:
* Firmware version: During setup, no generator connected.
* Hardware: Tested on Raspberry Pi 3A+ and Ubuntu VM.

## Checklist:

- [ ] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [ ] I have reasonably commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tested any python code on 3.x
- [ ] I have tested any javascript on most popular browsers for compatibility
