### PR TITLE
Add serial connection type question to genmonmaint

### DIFF
--- a/genmonmaint.sh
+++ b/genmonmaint.sh
@@ -171,11 +171,11 @@ function installgenmon() {
         s|S ) echo "Setting up serial port..."
           ;; # serial, nothing to do
         t|T ) echo "Not setting up serial port"
-          sudo sed -i 's/use_serial_tcp = False/use_serial_tcp = True/g' /etc/genmon/genmon.conf
+          sudo sed -i 's/use_serial_tcp = False/use_serial_tcp = True/gI' /etc/genmon/genmon.conf
           useserial=false
           ;; # TCP/IP bridge
         u|U ) echo "Not setting up serial port"
-          sudo sudo sed -i 's/\/dev\/serial0/\/dev\/ttyUSB0/g' /etc/genmon/genmon.conf
+          sudo sudo sed -i 's/\/dev\/serial0/\/dev\/ttyUSB0/gI' /etc/genmon/genmon.conf
           useserial=false
           ;; # USB Connection
         *)

--- a/genmonmaint.sh
+++ b/genmonmaint.sh
@@ -171,11 +171,11 @@ function installgenmon() {
         s|S ) echo "Setting up serial port..."
           ;; # serial, nothing to do
         t|T ) echo "Not setting up serial port"
-          sed -i 's/use_serial_tcp = False/use_serial_tcp = True/g' /etc/genmon/genmon.conf
+          sudo sed -i 's/use_serial_tcp = False/use_serial_tcp = True/g' /etc/genmon/genmon.conf
           useserial=false
           ;; # TCP/IP bridge
         u|U ) echo "Not setting up serial port"
-          sudo sed -i 's/\/dev\/serial0/\/dev\/ttyUSB0/g' /etc/genmon/genmon.conf
+          sudo sudo sed -i 's/\/dev\/serial0/\/dev\/ttyUSB0/g' /etc/genmon/genmon.conf
           useserial=false
           ;; # USB Connection
         *)

--- a/genmonmaint.sh
+++ b/genmonmaint.sh
@@ -31,6 +31,8 @@ cleanpython_opt=false
 copyfiles_opt=false
 update_os=false
 managedpackages=false
+configfilescopied=false
+useserial=true
 
 #-------------------------------------------------------------------------------
 function checkmanagedpackages() {
@@ -150,6 +152,7 @@ function installgenmon() {
         case "$choice" in
           y|Y ) echo "Copying *.conf files to "$config_path""
             copyconffiles
+            configfilescopied=true
             ;; # yes choice
           n|N ) echo "Not copying *.conf to "$config_path""
             ;; # no choice
@@ -159,8 +162,29 @@ function installgenmon() {
         esac
     else
         copyconffiles
+        configfilescopied=true
     fi
-    if [ -z "$2" ] && [ $1 != "noprompt" ]; then    # Is parameter #1 zero length?
+
+    if [ "$configfilescopied" = true ] && [ -z "$2" ] && [ $1 != "noprompt" ]; then    # Is parameter #1 zero length?
+      read -p "What type of serial connection? S=Serial, T=TCP/IP Bridge, U=USB (s/t/u)?" choice
+      case "$choice" in
+        s|S ) echo "Setting up serial port..."
+          ;; # serial, nothing to do
+        t|T ) echo "Not setting up serial port"
+          sed -i 's/use_serial_tcp = False/use_serial_tcp = True/g' /etc/genmon/genmon.conf
+          useserial=false
+          ;; # TCP/IP bridge
+        u|U ) echo "Not setting up serial port"
+          sudo sed -i 's/\/dev\/serial0/\/dev\/ttyUSB0/g' /etc/genmon/genmon.conf
+          useserial=false
+          ;; # USB Connection
+        *)
+          echo "Invalid choice, defaulting to serial"
+          ;;  # default choice
+      esac
+    fi
+
+    if [ "$useserial" = true ] && [ -z "$2" ] && [ $1 != "noprompt" ]; then    # Is parameter #1 zero length?
       read -p "Setup the raspberry pi onboard serial port? (y/n)?" choice
       case "$choice" in
         y|Y ) echo "Setting up serial port..."

--- a/genmonmaint.sh
+++ b/genmonmaint.sh
@@ -184,20 +184,22 @@ function installgenmon() {
       esac
     fi
 
-    if [ "$useserial" = true ] && [ -z "$2" ] && [ $1 != "noprompt" ]; then    # Is parameter #1 zero length?
-      read -p "Setup the raspberry pi onboard serial port? (y/n)?" choice
-      case "$choice" in
-        y|Y ) echo "Setting up serial port..."
+    if [ "$useserial" = true ]; then
+      if [ -z "$2" ] && [ $1 != "noprompt" ]; then    # Is parameter #1 zero length?
+        read -p "Setup the raspberry pi onboard serial port? (y/n)?" choice
+        case "$choice" in
+          y|Y ) echo "Setting up serial port..."
+            setupserial
+            ;; # yes choice
+          n|N ) echo "Not setting up serial port"
+            ;; # no choice
+          *)
+            echo "Invalid choice, not setting up serial port"
+            ;;  # default choice
+        esac
+      else
           setupserial
-          ;; # yes choice
-        n|N ) echo "Not setting up serial port"
-          ;; # no choice
-        *)
-          echo "Invalid choice, not setting up serial port"
-          ;;  # default choice
-      esac
-    else
-        setupserial
+      fi
     fi
     echo "Done."
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Adding a user prompt to input the type of serial connection between serial, TCP/IP bridge, and USB.  This will hopefully help eliminate at least some of the instances where genmon aborts when because of an invalid serial port configuration.

New prompt only occurs if copy config files is yes.  It then skips the configure serial port question if TCP or USB is selected.

Feel free to modify or reject.

Fixes # [(issue)](https://github.com/jgyates/genmon/issues/801)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] RPi4 running Bookworm
- [X] VM running Ubuntu

**Test Configuration**:
* Firmware version:
* Hardware:

## Checklist:

- [ ] Are any new libraries required and have they been added to the install scripts
- [ ] My code follows the existing code style and formatting of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reasonably commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tested any python code on 3.x
- [ ] I have tested any javascript on most popular browsers for compatibility
