### PR TITLE
Increase maximum email password length

### DIFF
--- a/genserv.py
+++ b/genserv.py
@@ -3438,7 +3438,7 @@ def ReadSettingsFromFile():
         302,
         "password",
         "",
-        "max:50",
+        "max:70",
         MAIL_CONFIG,
         MAIL_SECTION,
         "email_pw",


### PR DESCRIPTION
# Pull Request Template

## Description

Some transactional email services (e.g. SendGrid) automatically generate long credentials and don't let you shorten them. This fix increases the minimum password length from 50 to 70.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally and confirmed emails still send correctly.

## Checklist:

- [x] Are any new libraries required and have they been added to the install scripts
- [x] My code follows the existing code style and formatting of this project
- [x] I have performed a self-review of my own code
- [x] I have reasonably commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested any python code on 3.x
- [x] I have tested any javascript on most popular browsers for compatibility
