### PR TITLE
Fix Pre-Assembled Hardware Link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project will monitor a backup generator that utilizes the Generac Controlle
 * Deep See Electronics 7320MKII Controller
 * [Briggs & Stratton GC-1031/GC-1032](https://github.com/jgyates/genmon/wiki/Appendix-P-Briggs-and-Stratton-Controller-Information)
 
-The project is written mostly in python and has been tested with a Raspberry Pi 3 (Pi Zero, Pi Zero W, Pi Zero 2W, Pi 2, Pi 3b+ and Pi 4 have also been validated). 32 and 64 bit version of raspbian have been used with the project. To use this project you would need to create a physical enclosure for your raspberry pi and possibly [make a cable](https://github.com/jgyates/genmon/wiki/3.1--Making-a-Cable) to connect the raspberry pi to the generator controller or purchase [pre-assembled hardware](https://github.com/jgyates/genmon/wiki#pre-assembled-hardware). If you are comfortable doing these things and you have a backup generator that has a supported controller, then this project may be of interest to you.
+The project is written mostly in python and has been tested with a Raspberry Pi 3 (Pi Zero, Pi Zero W, Pi Zero 2W, Pi 2, Pi 3b+ and Pi 4 have also been validated). 32 and 64 bit version of raspbian have been used with the project. To use this project you would need to create a physical enclosure for your raspberry pi and possibly [make a cable](https://github.com/jgyates/genmon/wiki/3.1--Making-a-Cable) to connect the raspberry pi to the generator controller or purchase [pre-assembled hardware](https://github.com/jgyates/genmon/wiki/2--Hardware#custom-hat). If you are comfortable doing these things and you have a backup generator that has a supported controller, then this project may be of interest to you.
 
 ## Functionality
 The software supports the following features:


### PR DESCRIPTION
# Pull Request Template

## Description

I noticed that clicking on the `pre-assembled hardware` link in the file `README.md` took me to the top of the wiki. I've updated the link to what seemed most appropriate.

Fixes (No issue created since it seems minor)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Click on the link.

**Test Configuration**: N/A
* Firmware version: N/A
* Hardware: N/A

## Checklist:

- [x] Are any new libraries required and have they been added to the install scripts
- [x] My code follows the existing code style and formatting of this project
- [x] I have performed a self-review of my own code
- [x] I have reasonably commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested any python code on 3.x
- [x] I have tested any javascript on most popular browsers for compatibility
