### PR TITLE
fix: add pip switch to give priority to pre-compiled package wheels, …

### DIFF
--- a/genmonmaint.sh
+++ b/genmonmaint.sh
@@ -16,7 +16,7 @@ Continue? (y/n)  "
 
 usepython3=true
 pipcommand="pip3"
-pipoptions=""
+pipoptions="--prefer-binary"
 pythoncommand="python3"
 OPTIND=1         # Reset in case getopts has been used previously in the shell.
 config_path="/etc/genmon/"


### PR DESCRIPTION
…if available

# Pull Request Template

## Description

Due to a series of unfortunate events, I had to re-image the SD card in my Pi zero and then re-install and re-configure genmon. During that process, I ran into countless issues where the installation script took ~10 hours to run as it was trying to manually compile the scipy package. Even after 10 hours, the scipy compilation failed with various errors related to cargo/rust that I couldn't figure out as the debug cycle was so long.

On further investigation, raspbian images default to using [piwheels](https://www.piwheels.org/) as a pip package source. Normally, this should allow pi users to get pre-compiled wheels for most pip packages. However, piwheels had [recent issues](https://github.com/piwheels/packages/issues/530) that caused the build backlog to get very long.  For example, the most recent wheel available for scipy is from [two months ago](https://www.piwheels.org/project/scipy/) and is 3 releases out of date.

You can see the issue even using the example from the piwheels homepage because by default pip tries to obtain the latest copy of scipy instead of the version from piwheels with a wheel available:
```bash
$ sudo apt install virtualenv python3-virtualenv -y
$ virtualenv -p /usr/bin/python3 testpip
$ source testpip/bin/activate
(testpip) $ pip install scipy
```

My original thought was to pin/freeze all of the pip package versions in `requirements.txt`, but `fluids` is the package genmon cares about. I could've explicitly added scipy/numpy versions pinned to the last wheels available from piwheels, but that will probably cause some future maintenance issues.

Digging deeper, I found that `pip install` has a [prefer-binary](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-prefer-binary) switch that does exactly what we want. By adding this, pip will automatically grab the latest copy of each package that has a pre-compiled wheel, if available. If not, there should be no functional change for users who are using non-pi hardware.

This could also have a positive impact if other hardware/OS combinations use a similar package registry as piwheels.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- re-ran the installation script on my pi-zero. The runtime went from ~12 hours down to ~20 minutes

**Test Configuration**:
* Firmware version:
* Hardware:

## Checklist:

- [ ] Are any new libraries required and have they been added to the install scripts
- [ ] My code follows the existing code style and formatting of this project
- [ ] I have performed a self-review of my own code
- [ ] I have reasonably commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tested any python code on 3.x
- [ ] I have tested any javascript on most popular browsers for compatibility
