### PR TITLE
Add Set Generator Time button and improve HA entity management

### DIFF
--- a/conf/genhomeassistant.conf
+++ b/conf/genhomeassistant.conf
@@ -89,8 +89,10 @@ client_key_path =
 
 # Optional. Entity blacklist. Comma-separated list of strings. Entities with
 # names containing any of these strings will not be created.
-# Example: blacklist = Packet Count, Platform Stats, CRC Errors
-blacklist =
+# Default: "Tiles" (excludes web UI tile data which duplicates existing sensors)
+# Example: blacklist = Tiles, Packet Count, Platform Stats, CRC Errors
+# To disable default blacklist, set to empty or your own list.
+blacklist = Tiles
 
 # Optional. Include platform/monitor statistics entities (CPU, memory, etc.)
 include_monitor_stats = True

--- a/data/homeassistant/base.json
+++ b/data/homeassistant/base.json
@@ -734,6 +734,12 @@
       "name": "Start Exercise",
       "command": "setremote=STARTEXERCISE",
       "icon": "mdi:dumbbell"
+    },
+    {
+      "entity_id": "set_time",
+      "name": "Set Generator Time",
+      "command": "settime",
+      "icon": "mdi:clock-edit"
     }
   ],
   "switches": [

--- a/data/homeassistant/generac_evo_nexus.json
+++ b/data/homeassistant/generac_evo_nexus.json
@@ -1,8 +1,42 @@
 {
   "controller_type": "evolution",
   "version": "1.0",
-  "description": "Evolution/Nexus controller-specific entity definitions (extends base)",
-  "sensors": [],
+  "description": "Evolution controller-specific entity definitions (extends base). Note: Service A/B/Battery Check are Evolution-only, not available on Nexus.",
+  "sensors": [
+    {
+      "entity_id": "service_a_due",
+      "name": "Service A Due",
+      "path": "Maintenance/Service/Service A Due",
+      "icon": "mdi:wrench-clock",
+      "category": "diagnostic",
+      "enabled_default": true,
+      "monitor_stats": false,
+      "weather": false,
+      "controllers": ["evolution"]
+    },
+    {
+      "entity_id": "service_b_due",
+      "name": "Service B Due",
+      "path": "Maintenance/Service/Service B Due",
+      "icon": "mdi:wrench-clock",
+      "category": "diagnostic",
+      "enabled_default": true,
+      "monitor_stats": false,
+      "weather": false,
+      "controllers": ["evolution"]
+    },
+    {
+      "entity_id": "battery_check_due",
+      "name": "Battery Check Due",
+      "path": "Maintenance/Service/Battery Check Due",
+      "icon": "mdi:battery-clock",
+      "category": "diagnostic",
+      "enabled_default": true,
+      "monitor_stats": false,
+      "weather": false,
+      "controllers": ["evolution"]
+    }
+  ],
   "binary_sensors": [],
   "buttons": [],
   "switches": [],


### PR DESCRIPTION
## Summary
- Add "Set Generator Time" button to sync generator clock with monitor time
- Add automatic stale entity cleanup when entity IDs change between versions
- Add Service A/B/Battery Check sensors (Evolution controllers only)
- Add custom controller support via `import_config_file` from start_info
- Add default blacklist for Tiles to reduce duplicate entities
- Update conf documentation for blacklist option

## Test plan
- [x] Verified "Set Generator Time" button appears in Home Assistant
- [x] Verified button successfully syncs generator time when pressed
- [x] Verified stale entity cleanup removes old entities on restart
- [x] Verified Service A/B/Battery Check sensors only appear on Evolution controllers
- [x] Verified Tiles entities are excluded by default blacklist

🤖 Generated with [Claude Code](https://claude.ai/code)