### PR TITLE
Restrict Nexus-only service sensors to Nexus controllers in HA addon

### DIFF
--- a/addon/genhomeassistant.py
+++ b/addon/genhomeassistant.py
@@ -325,6 +325,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:oil",
         "state_class": None,
         "category": "diagnostic",
+        "controllers": ["nexus"],
     },
     "air_filter_service": {
         "name": "Air Filter Service Due",
@@ -334,6 +335,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:air-filter",
         "state_class": None,
         "category": "diagnostic",
+        "controllers": ["nexus"],
     },
     "spark_plug_service": {
         "name": "Spark Plug Service Due",
@@ -343,6 +345,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:flash",
         "state_class": None,
         "category": "diagnostic",
+        "controllers": ["nexus"],
     },
     "battery_service": {
         "name": "Battery Service Due",
@@ -352,6 +355,7 @@ SENSOR_DEFINITIONS = {
         "icon": "mdi:car-battery",
         "state_class": None,
         "category": "diagnostic",
+        "controllers": ["nexus"],
     },
     # Outage sensors
     "outage_status": {

--- a/data/homeassistant/base.json
+++ b/data/homeassistant/base.json
@@ -340,7 +340,8 @@
       "category": "diagnostic",
       "enabled_default": true,
       "monitor_stats": false,
-      "weather": false
+      "weather": false,
+      "controllers": ["nexus"]
     },
     {
       "entity_id": "air_filter_service",
@@ -350,7 +351,8 @@
       "category": "diagnostic",
       "enabled_default": true,
       "monitor_stats": false,
-      "weather": false
+      "weather": false,
+      "controllers": ["nexus"]
     },
     {
       "entity_id": "spark_plug_service",
@@ -360,7 +362,8 @@
       "category": "diagnostic",
       "enabled_default": true,
       "monitor_stats": false,
-      "weather": false
+      "weather": false,
+      "controllers": ["nexus"]
     },
     {
       "entity_id": "battery_service",
@@ -370,7 +373,8 @@
       "category": "diagnostic",
       "enabled_default": true,
       "monitor_stats": false,
-      "weather": false
+      "weather": false,
+      "controllers": ["nexus"]
     },
     {
       "entity_id": "outage_status",


### PR DESCRIPTION
## Summary
- Add `controllers: ["nexus"]` restriction to service due sensors that only exist on Nexus controllers
- Prevents these sensors from being created on Evolution controllers where the data paths don't exist

## Problem
On Evolution controllers, the following sensors were being created even though Evolution doesn't generate these data paths:
- `oil_service` (Oil and Filter Service Due)
- `air_filter_service` (Air Filter Service Due)
- `spark_plug_service` (Spark Plug Service Due)
- `battery_service` (Battery Service Due)

Evolution controllers use Service A/B instead. The stale sensors on Evolution systems showed truncated or invalid values.

## Solution
Added `"controllers": ["nexus"]` to these sensor definitions in both:
- `data/homeassistant/base.json`
- `addon/genhomeassistant.py` (hardcoded fallback)

The existing `_cleanup_stale_entities()` function will automatically remove these sensors from Home Assistant on Evolution systems when the addon restarts.

## Test plan
- [x] Verified on Nexus AC system - service sensors continue to work correctly
- [ ] User with Evolution controller should verify sensors are cleaned up after update

Fixes #1370

🤖 Generated with [Claude Code](https://claude.ai/code)