### PR TITLE
Add custom controller button support to HA addon

### DIFF
--- a/data/homeassistant/MEBAY_DCxx.json
+++ b/data/homeassistant/MEBAY_DCxx.json
@@ -1,0 +1,11 @@
+{
+  "controller_type": "custom",
+  "version": "1.0",
+  "description": "MEBAY DCxx controller entity definitions (extends base). Buttons are loaded dynamically from controller StartInfo.",
+  "sensors": [],
+  "binary_sensors": [],
+  "buttons": [],
+  "switches": [],
+  "selects": [],
+  "numbers": []
+}

--- a/genmonlib/custom_controller.py
+++ b/genmonlib/custom_controller.py
@@ -1060,6 +1060,7 @@ class CustomController(GeneratorController):
             StartInfo["FuelConsumption"] = self.FuelConsumptionSupported()
             StartInfo["Controller"] = self.GetController(Actual=False)
             StartInfo["Actual"] = self.GetController(Actual=True)
+            StartInfo["import_config_file"] = self.ConfigImportFile
             StartInfo["UtilityVoltage"] = False
             StartInfo["RemoteCommands"] = False  # Remote Start/ Stop/ StartTransfer
             StartInfo["ResetAlarms"] = False

--- a/genserv.py
+++ b/genserv.py
@@ -1675,10 +1675,10 @@ def GetAddOns():
         )
         AddOnCfg["genhomeassistant"]["parameters"]["blacklist"] = CreateAddOnParam(
             ConfigFiles[GENHOMEASSISTANT_CONFIG].ReadValue(
-                "blacklist", return_type=str, default=""
+                "blacklist", return_type=str, default="Tiles"
             ),
             "string",
-            "Comma-separated list of strings. Entities with names containing these strings will not be created.",
+            "Comma-separated list of strings. Entities with names containing these strings will not be created. Matches against entity name, ID, and data path.",
             bounds="",
             display_name="Entity Blacklist",
         )
@@ -1780,6 +1780,15 @@ def GetAddOns():
             "Unique MQTT client identifier. Must be unique per genmon instance.",
             bounds="",
             display_name="Client ID",
+        )
+        AddOnCfg["genhomeassistant"]["parameters"]["button_passcode"] = CreateAddOnParam(
+            ConfigFiles[GENHOMEASSISTANT_CONFIG].ReadValue(
+                "button_passcode", return_type=str, default=""
+            ),
+            "password",
+            "Passcode for controllers that require authentication for remote commands (e.g. MEBAY). Leave empty if not required.",
+            bounds="",
+            display_name="Button Passcode",
         )
         AddOnCfg["genhomeassistant"]["parameters"]["debug"] = CreateAddOnParam(
             ConfigFiles[GENHOMEASSISTANT_CONFIG].ReadValue(


### PR DESCRIPTION
## Summary

Custom controllers (MEBAY, DeepSea, etc.) define their own buttons via StartInfo but the HA addon previously skipped them because `RemoteCommands` was hardcoded to `False`. This adds dynamic button discovery from controller StartInfo and executes them via the `set_button_command` API with optional passcode injection. (Addresses #1381)

### Changes
- `custom_controller.py`: Expose `import_config_file` in StartInfo for HA addon controller mapping
- `genhomeassistant.py`: Dynamic button loading from StartInfo, `set_button_command` handler with passcode, bypass `RemoteCommands` gating for controller-sourced buttons
- `genserv.py`: Add `button_passcode` password field to HA addon settings UI
- `data/homeassistant/MEBAY_DCxx.json`: New HA entity definition file for MEBAY controllers

## Test plan

- [ ] Verify Generac Evolution/Nexus controllers still work with existing `setremote` button commands (backward compatibility)
- [ ] Verify `button_passcode` appears in genmon web UI under HA addon settings as a password field
- [ ] With a MEBAY or DeepSea controller, verify buttons from StartInfo appear in Home Assistant
- [ ] Verify button press sends `set_button_command` JSON with passcode injected for custom controller buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)