### PR TITLE
Update "Click here to reload" link

### DIFF
--- a/static/js/genmon.js
+++ b/static/js/genmon.js
@@ -415,7 +415,7 @@ var Modal = {
             $('.restart-countdown').html(
               'The service may have restarted but the browser cannot connect.<br>' +
               'This can happen when a self-signed certificate has changed.<br><br>' +
-              '<a href="' + esc(location.href) + '" style="color:var(--accent);font-weight:600">' +
+              '<a href="/" style="color:var(--accent);font-weight:600">' +
               'Click here to reload</a><br>' +
               '<span style="font-size:.85em;color:var(--text-muted)">If you see a certificate warning, accept it and then reload again.</span>'
             );


### PR DESCRIPTION
# Pull Request Template

## Description

Updating the link in the "Click here to reload" that pops up after saving a setting when the auto-checker fails to find genmon up. With this change, it sends back to / instead of trying to navigate back to the current page since trying to navigate to the anchor isn't a change that causes the browser to reprompt to accept the new self-signed cert.

Fixes #1416 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Tested with my local install first with self signed cert.

**Test Configuration**:
* Firmware version: 
* Hardware: 

## Checklist:

- [X] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [X] I have reasonably commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested any python code on 3.x
- [X] I have tested any javascript on most popular browsers for compatibility

Feel free to decline and do something else if a different solution may be more appropriate or if this comes up for things other than self-signed certs.