### PR TITLE
Add milliamp unit to genhalink

### DIFF
--- a/addon/genhalink.py
+++ b/addon/genhalink.py
@@ -884,14 +884,15 @@ class GenHALink(MySupport):
 
     def _extract_unit(self, value_str):
         match = re.search(
-            r"[\d.]+\s*(V|A|W|kW|kVA|Hz|°[CF]|dBm|%|RPM|gal|hours|h|C|F)\s*$",
+            r"[\d.]+\s*(V|A|mA|W|kW|kVA|Hz|°[CF]|dBm|%|RPM|gal|hours|h|C|F)\s*$",
             str(value_str),
         )
         return match.group(1) if match else None
 
     def _unit_to_device_class(self, unit):
         mapping = {
-            "V": "voltage", "A": "current", "W": "power", "kW": "power",
+            "V": "voltage", "A": "current", "mA": "current", 
+            "W": "power", "kW": "power",
             "kVA": "apparent_power",
             "Hz": "frequency",
             "°C": "temperature", "°F": "temperature",


### PR DESCRIPTION
# Pull Request Template

## Description

The native Home Assistant addon, genhalink, was not reporting proper device_class for sensors that use milliamp units (aka "mA").  This is used for the battery charging current.  As a result Home Assistant was not tracking them as measurement sensors.  This PR simple adds the "mA" unit and maps to a device_class of "current"

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally and confirmed that the "battery_charger_current" sensor is now reported as "measurement" state_class and "current" device_class

**Test Configuration**:
* Firmware version: V1.18
* Hardware: Evolution 2.0

## Checklist:

- [ ] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [ ] I have reasonably commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested any python code on 3.x
- [ ] I have tested any javascript on most popular browsers for compatibility
