### PR TITLE
Fix conditional check for tank dimensions

### DIFF
--- a/addon/genmopeka.py
+++ b/addon/genmopeka.py
@@ -533,7 +533,7 @@ class GenMopekaData(MySupport):
                 self.LogDebug(
                     "No tank dimensions found for tank type " + str(self.tank_type)
                 )
-                if self.max_mm != None or self.min_mm != None:
+                if self.max_mm == None or self.min_mm == None:
                     self.LogDebug(
                         "Error: min: "
                         + str(self.min_mm)


### PR DESCRIPTION
# Pull Request Template

## Description

Corrects logging added for #1310.  The original code returned nothing when max_mm and min_mm contained valid values.

Fixes # (1310)

## Type of change

Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**Test Configuration**:
* Genmon: 2.0.0
* Genmon UI: 2.0.0
* Firmware version: 1.18
* Python: 3.11
* Generator Hardware: Evolution 2.0
* Tank Sensor Hardware: Mopeka Pro Check Universal
* Tank Size: 320 gallons

Test A
Configuration 
 tank_type = Custom
 max_mm = 720
 min_mm = 0
 debug = true

Test B
Configuration 
 tank_type = Custom
 max_mm = 720
 min_mm = 0
 debug = false

Test C
Configuration 
 tank_type = 500_GAL
 max_mm = 720
 min_mm = 0
 debug = true

Test D
Configuration 
 tank_type = Custom
 max_mm = 720
 min_mm = invalid
 debug = true

Test E
Configuration 
 tank_type = Custom
 max_mm = invalid
 min_mm = 0
 debug = true

Test F
Configuration 
 tank_type = Custom
 max_mm = invalid
 min_mm = invalid
 debug = true

Test G
Configuration 
 tank_type = Custom
 max_mm = 720
 min_mm = -1
 debug = true

Test H
Configuration 
 tank_type = Custom
 max_mm = -1
 min_mm = 0
 debug = true

Test I
Configuration 
 tank_type = Custom
 max_mm = -1
 min_mm = -1
 debug = true

Test J
Configuration 
 tank_type = Custom
 max_mm = 0
 min_mm = 0
 debug = true

Test K
Configuration 
 tank_type = Custom
 max_mm = 0
 min_mm = 1
 debug = true

Test J
Configuration 
 tank_type = Custom
 max_mm = 0
 min_mm = 720
 debug = true
