### PR TITLE
Update genserv.py to fix LDAP NTLM login issues

### DIFF
--- a/genserv.py
+++ b/genserv.py
@@ -689,7 +689,7 @@ def doLdapLogin(username, password):
     if LdapServer == None or LdapServer == "":
         return False
     try:
-        from ldap3 import ALL, NTLM, Connection, Server
+        from ldap3 import ALL, Connection, Server
         from ldap3.utils.dn import escape_rdn
         from ldap3.utils.conv import escape_filter_chars
     except ImportError as importException:
@@ -720,7 +720,8 @@ def doLdapLogin(username, password):
             authentication=NTLM,
             auto_bind=True,
         )
-        loginbasestr = escape_filter_chars("(&(objectclass=user)(sAMAccountName=" + AccountName + "))")
+        escaped_account = escape_filter_chars(AccountName)
+        loginbasestr = "(&(objectclass=user)(sAMAccountName=%s))" % escaped_account
         conn.search(
             LdapBase,
             loginbasestr,
@@ -733,17 +734,20 @@ def doLdapLogin(username, password):
                 elif group.upper().find("CN=" + LdapReadOnlyGroup.upper() + ",") >= 0:
                     HasReadOnly = True
         conn.unbind()
-    except Exception:
+    except Exception as eld1:
+        import traceback
         LogError("Error in LDAP login. Check credentials and config parameters")
+        LogDebug("LDAP login exception: " + repr(eld1))
+        LogDebug("LDAP login tracerback: " + traceback.format_exc())
 
     session["logged_in"] = HasAdmin or HasReadOnly
     session["write_access"] = HasAdmin
     if HasAdmin:
-        LogError("Admin Login via LDAP")
+        LogError("Admin Login via LDAP for user: " + AccountName)
     elif HasReadOnly:
-        LogError("Limited Rights Login via LDAP")
+        LogError("Limited Rights Login via LDAP for user: " + AccountName)
     else:
-        LogError("No rights for login via LDAP")
+        LogError("No rights for login via LDAP for user: " + AccountName)
 
     return HasAdmin or HasReadOnly
 


### PR DESCRIPTION
# Pull Request Template

## Description

Fix LDAP login as Genmon’s LDAP code is using ldap3 with NTLM, and NTLM needs MD4; on newer Python/OpenSSL builds, MD4 isn’t available through hashlib by default and fixing it requires unnecessary additional changes.

Resolved by switching to simple bind over LDAP. This PR also adds a little more logging to the LDAP login.

Fixes # Cannot login with NTLM enabled:

tail -f /var/log/genserv.log
  File "/usr/lib/python3.13/hashlib.py", line 166, in __hash_new
    return __get_builtin_constructor(name)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.13/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
**ValueError: unsupported hash type MD4**

2026-05-05 18:49:28,691 : Error in LDAP login. Check credentials and config parameters
2026-05-05 18:49:28,691 : No rights for login via LDAP

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

[X] Test A tested that ldap allows valid login
[X] Test B tested that ldap denys invalid login

**Test Configuration**:
Firmware version: V2.0.0
Hardware: Generac

## Checklist:

- [X] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [X] I have reasonably commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested any python code on 3.x
- [X] I have tested any javascript on most popular browsers for compatibility
