### PR TITLE
Skip disabled add-on dependencies

### DIFF
--- a/genloader.py
+++ b/genloader.py
@@ -198,11 +198,184 @@ class Loader(MySupport):
             return default
 
     # ---------------------------------------------------------------------------
+    def LibraryDependency(
+        self,
+        ImportName,
+        InstallName=None,
+        Version=None,
+        LinuxOnly=False,
+        MinPython=None,
+    ):
+
+        return {
+            "import": ImportName,
+            "install": InstallName if InstallName != None else ImportName,
+            "version": Version,
+            "linuxonly": LinuxOnly,
+            "minpython": MinPython,
+        }
+
+    # ---------------------------------------------------------------------------
+    def GetDependencyRegistry(self):
+
+        # we will not use the check for configparser as this look like it is in backports on 2.7
+        # and our myconfig modules uses the default so this generates an error that is not warranted
+        # ['configparser','configparser',None],   # reading config files
+        return {
+            "base": [
+                self.LibraryDependency("flask"),  # Web server
+                self.LibraryDependency("serial", "pyserial"),  # Serial
+                self.LibraryDependency("crcmod"),  # Modbus CRC
+                self.LibraryDependency("pyowm"),  # Open Weather API
+                self.LibraryDependency("pytz"),  # Time zone support
+                self.LibraryDependency("pyotp", Version="2.3.0"),  # 2FA support
+                self.LibraryDependency("psutil"),  # process utilities
+                self.LibraryDependency("OpenSSL", "pyopenssl"),  # SSL
+                self.LibraryDependency("ldap3"),  # LDAP
+            ],
+            "addons": [
+                {
+                    "modules": ["gensnmp"],
+                    "dependencies": [
+                        self.LibraryDependency("pysnmp", Version="5.1.0"),
+                    ],
+                },
+                {
+                    "modules": ["gentankdiy"],
+                    "dependencies": [
+                        self.LibraryDependency("smbus", LinuxOnly=True),
+                    ],
+                },
+                {
+                    "modules": ["genpushover"],
+                    "dependencies": [
+                        self.LibraryDependency("chump"),
+                    ],
+                },
+                {
+                    "modules": ["gensms"],
+                    "dependencies": [
+                        self.LibraryDependency("twilio"),
+                    ],
+                },
+                {
+                    "modules": ["genmqtt", "genmqttin", "genhomeassistant"],
+                    "dependencies": [
+                        self.LibraryDependency(
+                            "paho.mqtt.client", "paho-mqtt", Version="1.6.1"
+                        ),
+                    ],
+                },
+                {
+                    "modules": ["gencthat"],
+                    "dependencies": [
+                        self.LibraryDependency("spidev", LinuxOnly=True),
+                    ],
+                },
+                {
+                    "modules": ["genhalink"],
+                    "dependencies": [
+                        self.LibraryDependency("aiohttp"),
+                    ],
+                },
+                {
+                    "modules": ["gensms_voip"],
+                    "dependencies": [
+                        self.LibraryDependency("voipms", Version="0.2.5"),
+                    ],
+                },
+                {
+                    "modules": ["genmopeka"],
+                    "dependencies": [
+                        self.LibraryDependency("fluids", MinPython=(3, 6)),
+                    ],
+                },
+            ],
+            "features": [
+                {
+                    "modules": ["genhalink"],
+                    "config": {
+                        "file": "genhalink.conf",
+                        "section": "genhalink",
+                        "option": "zeroconf_enabled",
+                        "default": True,
+                    },
+                    "dependencies": [
+                        self.LibraryDependency("zeroconf"),
+                    ],
+                },
+                {
+                    "config": {
+                        "file": "genmon.conf",
+                        "section": "GenMon",
+                        "option": "usemfa",
+                        "default": False,
+                    },
+                    "dependencies": [
+                        self.LibraryDependency("webauthn", Version="2.7.0"),
+                    ],
+                },
+            ],
+        }
+
+    # ---------------------------------------------------------------------------
+    def GetModuleList(self):
+
+        ModuleList = []
+        Seen = set()
+        DependencyRegistry = self.GetDependencyRegistry()
+
+        try:
+            for Module in DependencyRegistry["base"]:
+                ModuleList.append(Module)
+
+            for AddOn in DependencyRegistry["addons"]:
+                if not self.IsModuleEnabled(AddOn["modules"]):
+                    continue
+                for Module in AddOn["dependencies"]:
+                    Module = Module.copy()
+                    Module["modules"] = AddOn["modules"]
+                    ModuleList.append(Module)
+
+            for Feature in DependencyRegistry["features"]:
+                if "modules" in Feature:
+                    if not self.IsModuleEnabled(Feature["modules"]):
+                        continue
+                if not self.IsConfigOptionEnabled(
+                    Feature["config"]["file"],
+                    Feature["config"]["section"],
+                    Feature["config"]["option"],
+                    default=Feature["config"].get("default", False),
+                ):
+                    continue
+                for Module in Feature["dependencies"]:
+                    Module = Module.copy()
+                    if "modules" in Feature:
+                        Module["modules"] = Feature["modules"]
+                    Module["config"] = Feature["config"]
+                    ModuleList.append(Module)
+
+            DedupedList = []
+            for Module in ModuleList:
+                Key = (Module["import"], Module["install"], Module["version"])
+                if Key in Seen:
+                    continue
+                Seen.add(Key)
+                DedupedList.append(Module)
+            return DedupedList
+        except Exception as e1:
+            self.LogInfo("Error in GetModuleList: " + str(e1), LogLine=True)
+            return ModuleList
+
+    # ---------------------------------------------------------------------------
     def ShouldCheckLibrary(self, Module):
 
         try:
             if "linuxonly" in Module and self.bSystemIsNotLinux and Module["linuxonly"]:
                 return False
+            if "minpython" in Module and Module["minpython"] != None:
+                if sys.version_info < Module["minpython"]:
+                    return False
             if not self.IsModuleEnabled(Module.get("modules", None)):
                 return False
             if "config" in Module:
@@ -224,42 +397,13 @@ class Loader(MySupport):
         # this function checks the system to see if the required libraries are
         # installed. If they are not then an attempt is made to install them.
 
-        ModuleList = [
-            # Required modules are always checked. Optional modules are checked
-            # only when their owning add-on or feature is enabled.
-            {"import": "flask", "install": "flask", "version": None},  # Web server
-            # we will not use the check for configparser as this look like it is in backports on 2.7
-            # and our myconfig modules uses the default so this generates an error that is not warranted
-            # ['configparser','configparser',None],   # reading config files
-            {"import": "serial", "install": "pyserial", "version": None},  # Serial
-            {"import": "crcmod", "install": "crcmod", "version": None},  # Modbus CRC
-            {"import": "pyowm", "install": "pyowm", "version": None},  # Open Weather API
-            {"import": "pytz", "install": "pytz", "version": None},  # Time zone support
-            {"import": "pyotp", "install": "pyotp", "version": "2.3.0"},  # 2FA support
-            {"import": "psutil", "install": "psutil", "version": None},  # process utilities
-            {"import": "OpenSSL", "install": "pyopenssl", "version": None},  # SSL
-            {"import": "ldap3", "install": "ldap3", "version": None},  # LDAP
-            {"import": "pysnmp", "install": "pysnmp", "version": "5.1.0", "modules": ["gensnmp"]},  # SNMP
-            {"import": "smbus", "install": "smbus", "version": None, "linuxonly": True, "modules": ["gentankdiy"]},  # SMBus reading of tank sensors
-            {"import": "chump", "install": "chump", "version": None, "modules": ["genpushover"]},  # for genpushover
-            {"import": "twilio", "install": "twilio", "version": None, "modules": ["gensms"]},  # for gensms
-            {"import": "paho.mqtt.client", "install": "paho-mqtt", "version": "1.6.1", "modules": ["genmqtt", "genmqttin", "genhomeassistant"]},  # MQTT add-ons
-            {"import": "spidev", "install": "spidev", "version": None, "linuxonly": True, "modules": ["gencthat"]},  # spidev
-            {"import": "aiohttp", "install": "aiohttp", "version": None, "modules": ["genhalink"]},  # used in genhalink
-            {"import": "zeroconf", "install": "zeroconf", "version": None, "modules": ["genhalink"], "config": {"file": "genhalink.conf", "section": "genhalink", "option": "zeroconf_enabled", "default": True}},  # genhalink mDNS discovery
-            {"import": "webauthn", "install": "webauthn", "version": "2.7.0", "config": {"file": "genmon.conf", "section": "GenMon", "option": "usemfa", "default": False}},  # passkeys for MFA in genserv.py
-            {"import": "voipms", "install": "voipms", "version": "0.2.5", "modules": ["gensms_voip"]}       # voipms for gensms_voip
-            # ['fluids', 'fluids', None]              # fluids for genmopeka
-        ]
+        ModuleList = self.GetModuleList()
         try:
             ErrorOccured = False
 
             for Module in ModuleList:
 
                 if not self.ShouldCheckLibrary(Module):
-                    continue
-                # fluids is only for Python 3.6 and higher
-                if (Module["import"] == "fluids") and sys.version_info < (3, 6):
                     continue
                 if not self.LibraryIsInstalled(Module["import"]):
                     self.LogInfo(

--- a/genloader.py
+++ b/genloader.py
@@ -207,6 +207,8 @@ class Loader(MySupport):
         MinPython=None,
     ):
 
+        # ImportName is the module name used by importlib. InstallName is the
+        # package name used by pip, which can differ (e.g. serial -> pyserial).
         return {
             "import": ImportName,
             "install": InstallName if InstallName != None else ImportName,
@@ -218,6 +220,17 @@ class Loader(MySupport):
     # ---------------------------------------------------------------------------
     def GetDependencyRegistry(self):
 
+        # Dependency groups:
+        #   base     - always required for normal genmon/genserv startup
+        #   addons   - required only when at least one listed add-on is enabled
+        #   features - required only when a config option is enabled; a feature
+        #              may also list modules when both an add-on and an option
+        #              must be enabled before installing the dependency.
+        #
+        # Keep optional or unusually large packages out of base. For example,
+        # fluids is only needed by genmopeka, and zeroconf is only needed when
+        # genhalink mDNS discovery is enabled.
+        #
         # we will not use the check for configparser as this look like it is in backports on 2.7
         # and our myconfig modules uses the default so this generates an error that is not warranted
         # ['configparser','configparser',None],   # reading config files
@@ -293,6 +306,8 @@ class Loader(MySupport):
             ],
             "features": [
                 {
+                    # zeroconf is optional within genhalink. Do not install it
+                    # unless the add-on is enabled and mDNS discovery is on.
                     "modules": ["genhalink"],
                     "config": {
                         "file": "genhalink.conf",
@@ -305,6 +320,8 @@ class Loader(MySupport):
                     ],
                 },
                 {
+                    # webauthn is used for passkeys, which are only available
+                    # when MFA is enabled.
                     "config": {
                         "file": "genmon.conf",
                         "section": "GenMon",
@@ -326,9 +343,12 @@ class Loader(MySupport):
         DependencyRegistry = self.GetDependencyRegistry()
 
         try:
+            # Start with the unconditional core dependencies.
             for Module in DependencyRegistry["base"]:
                 ModuleList.append(Module)
 
+            # Add dependencies for enabled add-ons only. This keeps disabled
+            # add-ons from triggering pip installs during every genloader start.
             for AddOn in DependencyRegistry["addons"]:
                 if not self.IsModuleEnabled(AddOn["modules"]):
                     continue
@@ -337,6 +357,8 @@ class Loader(MySupport):
                     Module["modules"] = AddOn["modules"]
                     ModuleList.append(Module)
 
+            # Add dependencies for enabled feature flags. Some features also
+            # have an add-on owner, so both gates must pass before inclusion.
             for Feature in DependencyRegistry["features"]:
                 if "modules" in Feature:
                     if not self.IsModuleEnabled(Feature["modules"]):
@@ -355,6 +377,9 @@ class Loader(MySupport):
                     Module["config"] = Feature["config"]
                     ModuleList.append(Module)
 
+            # A package can be required through more than one path. Check it
+            # once so shared dependencies do not produce duplicate log/install
+            # attempts.
             DedupedList = []
             for Module in ModuleList:
                 Key = (Module["import"], Module["install"], Module["version"])
@@ -371,6 +396,9 @@ class Loader(MySupport):
     def ShouldCheckLibrary(self, Module):
 
         try:
+            # Final platform/version/config guard before importing or installing.
+            # GetModuleList already filters add-ons and features, but keeping
+            # this here preserves one validation path for any direct callers.
             if "linuxonly" in Module and self.bSystemIsNotLinux and Module["linuxonly"]:
                 return False
             if "minpython" in Module and Module["minpython"] != None:

--- a/genloader.py
+++ b/genloader.py
@@ -91,11 +91,6 @@ class Loader(MySupport):
         self.console = SetupLogger("genloader_console", log_file="", stream=True)
 
         try:
-            if self.Start:
-                if not self.CheckSystem():
-                    self.LogInfo("Error check system readiness. Exiting")
-                    sys.exit(2)
-
             self.CachedConfig = {}
 
             if not os.path.isdir(self.ConfigFilePath):
@@ -146,6 +141,11 @@ class Loader(MySupport):
                     self.LogInfo("Error validating config file, Exiting")
                     sys.exit(2)
 
+            if self.Start:
+                if not self.CheckSystem():
+                    self.LogInfo("Error check system readiness. Exiting")
+                    sys.exit(2)
+
             self.LoadOrder = self.GetLoadOrder()
 
             if self.Stop:
@@ -169,61 +169,110 @@ class Loader(MySupport):
             sys.exit(2)
 
     # ---------------------------------------------------------------------------
+    def IsModuleEnabled(self, ModuleList):
+
+        try:
+            if ModuleList == None or not len(ModuleList):
+                return True
+            for Module in ModuleList:
+                if Module in self.CachedConfig and self.CachedConfig[Module]["enable"]:
+                    return True
+            return False
+        except Exception as e1:
+            self.LogInfo("Error in IsModuleEnabled: " + str(e1), LogLine=True)
+            return False
+
+    # ---------------------------------------------------------------------------
+    def IsConfigOptionEnabled(self, ConfigFile, Section, Option, default=False):
+
+        try:
+            ConfigPath = os.path.join(self.ConfigFilePath, ConfigFile)
+            if not os.path.isfile(ConfigPath):
+                ConfigPath = os.path.join(self.ConfPath, ConfigFile)
+            if not os.path.isfile(ConfigPath):
+                return default
+            config = MyConfig(filename=ConfigPath, section=Section, log=self.log)
+            return config.ReadValue(Option, return_type=bool, default=default)
+        except Exception as e1:
+            self.LogInfo("Error in IsConfigOptionEnabled: " + str(e1), LogLine=True)
+            return default
+
+    # ---------------------------------------------------------------------------
+    def ShouldCheckLibrary(self, Module):
+
+        try:
+            if "linuxonly" in Module and self.bSystemIsNotLinux and Module["linuxonly"]:
+                return False
+            if not self.IsModuleEnabled(Module.get("modules", None)):
+                return False
+            if "config" in Module:
+                Config = Module["config"]
+                return self.IsConfigOptionEnabled(
+                    Config["file"],
+                    Config["section"],
+                    Config["option"],
+                    default=Config.get("default", False),
+                )
+            return True
+        except Exception as e1:
+            self.LogInfo("Error in ShouldCheckLibrary: " + str(e1), LogLine=True)
+            return True
+
+    # ---------------------------------------------------------------------------
     def CheckSystem(self):
 
         # this function checks the system to see if the required libraries are
         # installed. If they are not then an attempt is made to install them.
 
         ModuleList = [
-            # [import name , install name, required version, linux only if true]
-            ["flask", "flask", None],  # Web server
+            # Required modules are always checked. Optional modules are checked
+            # only when their owning add-on or feature is enabled.
+            {"import": "flask", "install": "flask", "version": None},  # Web server
             # we will not use the check for configparser as this look like it is in backports on 2.7
             # and our myconfig modules uses the default so this generates an error that is not warranted
             # ['configparser','configparser',None],   # reading config files
-            ["serial", "pyserial", None],  # Serial
-            ["crcmod", "crcmod", None],  # Modbus CRC
-            ["pyowm", "pyowm", None],  # Open Weather API
-            ["pytz", "pytz", None],  # Time zone support
-            ["pysnmp", "pysnmp", "5.1.0"],  # SNMP
-            ["ldap3", "ldap3", None],  # LDAP
-            ["smbus", "smbus", None, True],  # SMBus reading of temp sensors
-            ["pyotp", "pyotp", "2.3.0"],  # 2FA support
-            ["psutil", "psutil", None],  # process utilities
-            ["chump", "chump", None],  # for genpushover
-            ["twilio", "twilio", None],  # for gensms
-            ["paho.mqtt.client", "paho-mqtt", "1.6.1"],  # for genmqtt
-            ["OpenSSL", "pyopenssl", None],  # SSL
-            ["spidev", "spidev", None, True],  # spidev
-            ["zeroconf", "zeroconf", None],     # used in genhomassistant  
-            ["aiohttp", "aiohttp", None],       # used in genhomassistant  
-            ["webauthn", "webauthn", "2.7.0"],  # used in MFA in genserv.py
-            ["voipms", "voipms", "0.2.5"]       # voipms for gensms_voip
+            {"import": "serial", "install": "pyserial", "version": None},  # Serial
+            {"import": "crcmod", "install": "crcmod", "version": None},  # Modbus CRC
+            {"import": "pyowm", "install": "pyowm", "version": None},  # Open Weather API
+            {"import": "pytz", "install": "pytz", "version": None},  # Time zone support
+            {"import": "pyotp", "install": "pyotp", "version": "2.3.0"},  # 2FA support
+            {"import": "psutil", "install": "psutil", "version": None},  # process utilities
+            {"import": "OpenSSL", "install": "pyopenssl", "version": None},  # SSL
+            {"import": "ldap3", "install": "ldap3", "version": None},  # LDAP
+            {"import": "pysnmp", "install": "pysnmp", "version": "5.1.0", "modules": ["gensnmp"]},  # SNMP
+            {"import": "smbus", "install": "smbus", "version": None, "linuxonly": True, "modules": ["gentankdiy"]},  # SMBus reading of tank sensors
+            {"import": "chump", "install": "chump", "version": None, "modules": ["genpushover"]},  # for genpushover
+            {"import": "twilio", "install": "twilio", "version": None, "modules": ["gensms"]},  # for gensms
+            {"import": "paho.mqtt.client", "install": "paho-mqtt", "version": "1.6.1", "modules": ["genmqtt", "genmqttin", "genhomeassistant"]},  # MQTT add-ons
+            {"import": "spidev", "install": "spidev", "version": None, "linuxonly": True, "modules": ["gencthat"]},  # spidev
+            {"import": "aiohttp", "install": "aiohttp", "version": None, "modules": ["genhalink"]},  # used in genhalink
+            {"import": "zeroconf", "install": "zeroconf", "version": None, "modules": ["genhalink"], "config": {"file": "genhalink.conf", "section": "genhalink", "option": "zeroconf_enabled", "default": True}},  # genhalink mDNS discovery
+            {"import": "webauthn", "install": "webauthn", "version": "2.7.0", "config": {"file": "genmon.conf", "section": "GenMon", "option": "usemfa", "default": False}},  # passkeys for MFA in genserv.py
+            {"import": "voipms", "install": "voipms", "version": "0.2.5", "modules": ["gensms_voip"]}       # voipms for gensms_voip
             # ['fluids', 'fluids', None]              # fluids for genmopeka
         ]
         try:
             ErrorOccured = False
-            if not self.bSystemIsNotLinux:
-                self.CheckToolsNeeded()
 
             for Module in ModuleList:
 
-                if len(Module) > 3:
-                    if self.bSystemIsNotLinux & Module[3]:
-                        # skip the verification as it will not be loaded on this platform
-                        continue 
-                # fluids is only for Python 3.6 and higher
-                if (Module[0] == "fluids") and sys.version_info < (3, 6):
+                if not self.ShouldCheckLibrary(Module):
                     continue
-                if not self.LibraryIsInstalled(Module[0]):
+                # fluids is only for Python 3.6 and higher
+                if (Module["import"] == "fluids") and sys.version_info < (3, 6):
+                    continue
+                if not self.LibraryIsInstalled(Module["import"]):
                     self.LogInfo(
                         "Warning: required library "
-                        + Module[1]
+                        + Module["install"]
                         + " not installed. Attempting to install...."
                     )
-                    if not self.InstallLibrary(Module[1], version=Module[2]):
-                        self.LogInfo("Error: unable to install library " + Module[1])
+                    if not self.bSystemIsNotLinux:
+                        self.CheckToolsNeeded()
+                    if not self.InstallLibrary(Module["install"], version=Module["version"]):
+                        self.LogInfo("Error: unable to install library " + Module["install"])
                         ErrorOccured = True
-                    if Module[0] == "ldap3":
+                    if Module["import"] == "ldap3":
                         # This will correct and issue with the ldap3 modbule not being recogonized in LibrayIsInstalled
                         self.InstallLibrary("pyasn1", update=True)
 


### PR DESCRIPTION
Summary: Make genloader parse genloader.conf before dependency checks, then resolve dependencies from a registry grouped by base requirements, add-on owners, and feature flags. Disabled add-ons no longer trigger optional package installs. genhalink now installs aiohttp only when enabled, zeroconf only when genhalink is enabled and zeroconf_enabled is true, webauthn only when MFA is enabled, and genmopeka installs fluids only when the Mopeka add-on is enabled on Python 3.6+. The loader also defers toolchain checks until a missing library actually needs installation. Validation: python3 -m py_compile genloader.py; git diff --check; dependency registry checks for disabled defaults, genmopeka/fluids, and genhalink mDNS on/off.