### PR TITLE
Re-add milliamps as units to resolve issue with charging current

### DIFF
--- a/addon/genhalink.py
+++ b/addon/genhalink.py
@@ -960,14 +960,15 @@ class GenHALink(MySupport):
 
     def _extract_unit(self, value_str):
         match = re.search(
-            r"[\d.]+\s*(V|A|W|kW|kVA|Hz|°[CF]|dBm|%|RPM|gal|hours|h|C|F)\s*$",
+            r"[\d.]+\s*(V|A|mA|W|kW|kVA|Hz|°[CF]|dBm|%|RPM|gal|hours|h|C|F)\s*$",
             str(value_str),
         )
         return match.group(1) if match else None
 
     def _unit_to_device_class(self, unit):
         mapping = {
-            "V": "voltage", "A": "current", "W": "power", "kW": "power",
+            "V": "voltage", "W": "power", "kW": "power",
+            "A": "current", "mA": "current",
             "kVA": "apparent_power",
             "Hz": "frequency",
             "°C": "temperature", "°F": "temperature",


### PR DESCRIPTION
# Pull Request Template

## Description

Re-add milliamps as a valid unit in Genhalink, which was reverted in commit 8d86a71f1562344d7957fa8adad4f4cb104338b3.  Without this fix 'Status/Engine/Battery Charger Current' is again reported without a measurement state_class resulting in Home Assistant treating it as a string value.  With this fix, units, state_class, and device_class get properly set as:

```
   {
      "entity_id": "status_engine_battery_charger_current",
      "name": "Battery Charger Current",
      "path": "Status/Engine/Battery Charger Current",
      "dynamic": true,
      "unit": "mA",
      "state_class": "measurement",
      "device_class": "current"
    }
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run locally.  Manually verified JSON output at https://genmon:9083/api/entities.  Confirmed correct status in Home Assistant.

**Test Configuration**:
* Firmware version: V1.18
* Hardware: Evolution 2.0 (Generac 22 kW)

## Checklist:

- [ ] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [ ] I have reasonably commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested any python code on 3.x
- [ ] I have tested any javascript on most popular browsers for compatibility
