### PR TITLE
Add TempSensors to StartInfo for dashboard temperature graphs

### DIFF
--- a/genmonlib/controller.py
+++ b/genmonlib/controller.py
@@ -1262,6 +1262,7 @@ class GeneratorController(MySupport):
             StartInfo["phase"] = self.Phase
             StartInfo["Controller"] = "Generic Controller Name"
             StartInfo["PowerGraph"] = self.PowerMeterIsSupported()
+            StartInfo["TempSensors"] = self.GetTempSensorNames()
             StartInfo["NominalBatteryVolts"] = "12"
             StartInfo["UtilityVoltageDisplayed"] = True
             StartInfo["RemoteCommands"] = True


### PR DESCRIPTION
## Summary
- Adds `StartInfo["TempSensors"] = self.GetTempSensorNames()` to `GetStartInfo()` in `controller.py`
- Without this, the frontend JS reads `info.TempSensors` as `[]` and temperature chart tiles never render on the dashboard

## Context
This line was missed when the temperature graphs feature was incorporated in 2.0.1. The JS expects `TempSensors` in the StartInfo payload to know which sensors to create chart tiles for.

## Test plan
- Verify temperature chart tiles appear on the dashboard when external sensor gauges are configured