### PR TITLE
perf: read available serial bytes in one syscall instead of one byte at a time

### DIFF
--- a/genmonlib/myserial.py
+++ b/genmonlib/myserial.py
@@ -158,16 +158,15 @@ class SerialDevice(MySupport):
             try:
                 self.Flush()
                 while True:
-                    for c in self.Read():
+                    data = self.Read()
+                    if len(data):
                         with self.BufferLock:
                             if sys.version_info[0] < 3:
-                                self.Buffer.append(ord(c))  # PYTHON2
+                                self.Buffer.extend(ord(c) for c in data)  # PYTHON2
                             else:
-                                self.Buffer.append(c)  # PYTHON3
-                        # first check for SignalStopped is when we are receiving
-                        if self.IsStopSignaled("SerialReadThread"):
-                            return
-                    # second check for SignalStopped is when we are not receiving
+                                self.Buffer.extend(data)  # PYTHON3 (bytes -> ints)
+                    # check for SignalStopped once per read (the read above blocks up
+                    # to the configured timeout, so this is not a busy loop)
                     if self.IsStopSignaled("SerialReadThread"):
                         return
 
@@ -227,8 +226,13 @@ class SerialDevice(MySupport):
 
     # ---------- SerialDevice::Read---------------------------------------------
     def Read(self):
-        # self.SerialDevice.inWaiting returns number of bytes ready
-        return (self.SerialDevice.read())  
+        # Read every byte currently available in a single syscall (or block for one
+        # byte when idle, preserving the configured read timeout). Reading one byte
+        # per call ("self.SerialDevice.read()" defaults to size=1) issued ~200
+        # read() syscalls/sec on a live system; in_waiting collapses a full frame
+        # into one read.
+        waiting = self.SerialDevice.in_waiting
+        return self.SerialDevice.read(waiting if waiting else 1)
 
     # ---------- SerialDevice::Write--------------------------------------------
     def Write(self, data):


### PR DESCRIPTION
## Summary
`SerialDevice.Read()` returned a **single byte** (`serial.read()` defaults to `size=1`), so the read thread issued **one `read()` syscall per byte** and took the buffer lock + checked the stop-signal **per byte**:

```python
def Read(self):
    return (self.SerialDevice.read())          # one byte

# ReadThread:
for c in self.Read():                          # 1-byte result
    with self.BufferLock:                      # lock per byte
        self.Buffer.append(c)
    if self.IsStopSignaled(...): return        # stop-check per byte
```

This PR reads everything currently available in one call via `in_waiting` (or blocks for one byte when idle, preserving the read timeout), and extends the buffer in bulk:

```python
def Read(self):
    waiting = self.SerialDevice.in_waiting
    return self.SerialDevice.read(waiting if waiting else 1)
```

**Buffer contents are byte-identical** (a list of ints; PY2/PY3 paths preserved), and the idle/timeout behavior is unchanged.

## Measured (live Raspberry Pi, Generac Evolution controller)
`strace -f -e trace=read` on the running genmon process:
```
before: ~239 read() syscalls/sec
after:  ~80  read() syscalls/sec     (-66%)
```
py-spy (`--gil`, on-CPU only) before vs after — the serial-read share drops and the per-byte read-thread frames disappear:
```
before:  read(serialposix) ~10.8%  +  ReadThread(myserial:161/162) ~3.3%   = ~14%
after:   read(serialposix) ~4.7%   +  Read(myserial)+in_waiting    ~2.9%   = ~7.6%
```
(It's ~3× not ~10× because bytes arrive incrementally at baud rate, so `in_waiting` is often small when the thread wakes — but it removes ~160 syscalls/sec plus the per-byte lock/stop-check overhead.)

## Correctness / validation
- Ran patched on a live generator for >5 min: controller comms healthy, and the web UI (`/cmd/status_json`) served full live, **updating** data throughout (battery/charger values changing) — identical behavior to stock.
- Mock-serial unit test (byte-identical buffer + read-call count). genmon has no test suite so it isn't added to the tree; included here for reference:

<details><summary>mock-serial test used to verify</summary>

```python
class FakeSerial:
    def __init__(self, data): self._d, self._p, self.read_calls = data, 0, 0
    @property
    def in_waiting(self): return len(self._d) - self._p
    def read(self, size=1):
        self.read_calls += 1
        chunk = self._d[self._p:self._p+size]; self._p += len(chunk); return chunk

def test_buffer_identical_and_far_fewer_reads():
    frame = bytes(range(64))
    old = FakeSerial(frame); buf_old = []
    while old.in_waiting:
        for c in old.read(1): buf_old.append(c)          # old: 1 byte/read
    new = FakeSerial(frame)
    sd = SerialDevice.__new__(SerialDevice); sd.SerialDevice = new
    buf_new = []
    while new.in_waiting: buf_new.extend(sd.Read())       # new: bulk
    assert buf_new == buf_old == list(frame)              # byte-identical
    assert old.read_calls == 64 and new.read_calls == 1   # 64 reads -> 1
```
</details>
