### PR TITLE
Add Otodata TM6030 BLE propane tank sensor addon (genotodata)

### DIFF
--- a/addon/genotodata.py
+++ b/addon/genotodata.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# -------------------------------------------------------------------------------
+#    FILE: genotodata.py
+# PURPOSE: Genmon addon for the Otodata TM6030 Bluetooth Low Energy propane
+#          tank sensor.  The TM6030 broadcasts its tank fill level as a
+#          percentage in the BLE advertisement local name, e.g.:
+#              "Otodata level: 72%"
+#          This addon scans for that advertisement and forwards the reading to
+#          genmon via the set_tank_data command.
+#
+#  AUTHOR: Brian Wilson
+#    DATE: 2024
+#
+#   USAGE: Copy to /home/pi/genmon/addon/
+#          Copy genotodata.conf to /etc/genmon/
+#          Add [genotodata] section to /etc/genmon/genloader.conf (see below)
+#          Run the genmon installation script to install dependencies (bleak)
+#
+#          [genotodata]
+#          module = genotodata.py
+#          enable = True
+#          hardstop = False
+#          conffile = genotodata.conf
+#          args =
+#          priority = 2
+#          postloaddelay = 0
+# -------------------------------------------------------------------------------
+
+import asyncio
+import json
+import os
+import re
+import sys
+import threading
+import time
+
+# ---------------------------------------------------------------------------
+# Ensure genmonlib is importable when invoked by genloader without PYTHONPATH.
+# The addon lives in <genmon_root>/addon/; genmonlib is one level up.
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# ---------------------------------------------------------------------------
+# Optional BLE dependency — log a clear message if missing rather than crash.
+# Install with: sudo pip3 install bleak
+# ---------------------------------------------------------------------------
+try:
+    from bleak import BleakScanner
+
+    bleak_installed = True
+except ImportError:
+    bleak_installed = False
+
+from genmonlib.myclient import ClientInterface
+from genmonlib.myconfig import MyConfig
+from genmonlib.mysupport import MySupport
+from genmonlib.mythread import MyThread
+
+# ---------------------------------------------------------------------------
+LEVEL_REGEX = re.compile(r"level:\s*([0-9]+(?:\.[0-9]+)?)\s*%", re.IGNORECASE)
+
+
+class GenOtodataData(MySupport):
+
+    def __init__(
+        self,
+        log=None,
+        loglocation=None,
+        ConfigFilePath=None,
+        host="localhost",
+        port=9082,
+        console=None,
+    ):
+        super(GenOtodataData, self).__init__()
+
+        self.log = log
+        self.loglocation = loglocation
+        self.console = console
+        self.host = host
+        self.port = port
+        self.running = True
+        self.current_level = None
+        self.CommAccessLock = threading.Lock()
+
+        if not bleak_installed:
+            self.LogError(
+                "GenOtodataData: Required library 'bleak' is not installed. "
+                "Run the genmon installation script or: sudo pip3 install bleak"
+            )
+            self.running = False
+            return
+
+        conf_path = os.path.join(
+            ConfigFilePath if ConfigFilePath else "/etc/genmon/",
+            "genotodata.conf",
+        )
+        self.config = MyConfig(filename=conf_path, section="genotodata", log=self.log)
+
+        self.tank_name = self.config.ReadValue(
+            "tank_name", return_type=str, default="Propane Tank"
+        )
+        self.capacity = self.config.ReadValue("capacity", return_type=int, default=0)
+        self.poll_frequency = self.config.ReadValue(
+            "poll_frequency", return_type=int, default=5
+        )
+        self.scan_time = self.config.ReadValue(
+            "scan_time", return_type=float, default=30.0
+        )
+        self.mac_address = (
+            self.config.ReadValue("mac_address", return_type=str, default="")
+            .strip()
+            .lower()
+        )
+
+        try:
+            self.Generator = ClientInterface(host=host, port=port, log=self.log)
+        except Exception as e1:
+            self.LogErrorLine(
+                "GenOtodataData: Cannot connect to genmon at %s:%d: %s"
+                % (host, port, str(e1))
+            )
+            self.Generator = None
+
+        self.Threads["TankCheckThread"] = MyThread(
+            self.TankCheckThread, Name="TankCheckThread"
+        )
+        self.LogError("GenOtodataData: Started.")
+
+    # ------------------------------------------------------------------
+    def SendCommand(self, Command):
+        if not Command:
+            return "Invalid command"
+        if self.Generator is None:
+            return ""
+        try:
+            with self.CommAccessLock:
+                return self.Generator.ProcessMonitorCommand(Command)
+        except Exception as e1:
+            self.LogErrorLine("Error in SendCommand: " + str(e1))
+            return ""
+
+    # ------------------------------------------------------------------
+    async def _ble_scan_async(self):
+        """Scan for scan_time seconds; return (address, level_pct) or (None, None)."""
+        result = {}
+
+        def _callback(device, adv_data):
+            name = device.name or (adv_data.local_name if adv_data else "") or ""
+            m = LEVEL_REGEX.search(name)
+            if not m:
+                return
+            addr = device.address.lower()
+            if self.mac_address and addr != self.mac_address:
+                return
+            result["addr"] = device.address
+            result["level"] = float(m.group(1))
+
+        scanner = BleakScanner(detection_callback=_callback)
+        await scanner.start()
+        await asyncio.sleep(self.scan_time)
+        await scanner.stop()
+        return result.get("addr"), result.get("level")
+
+    def GetTankReading(self):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(self._ble_scan_async())
+        except Exception as e1:
+            self.LogErrorLine("GenOtodataData: BLE scan error: " + str(e1))
+            return None, None
+        finally:
+            loop.close()
+
+    # ------------------------------------------------------------------
+    def TankCheckThread(self):
+        # Brief startup delay so genmon can fully initialise before we connect.
+        if self.WaitForExit("TankCheckThread", 5):
+            return
+
+        while True:
+            self.LogError(
+                "GenOtodataData: Scanning %.0f s for Otodata TM6030 sensor..."
+                % self.scan_time
+            )
+            addr, level = self.GetTankReading()
+
+            if level is not None:
+                self.LogError(
+                    "GenOtodataData: Sensor [%s] level %.1f%%" % (addr, level)
+                )
+                if level != self.current_level:
+                    self.current_level = level
+                    data = {"Tank Name": self.tank_name, "Percentage": level}
+                    if self.capacity > 0:
+                        data["Capacity"] = self.capacity
+                    self.SendCommand(
+                        "generator: set_tank_data=" + json.dumps(data)
+                    )
+            else:
+                self.LogError(
+                    "GenOtodataData: Sensor not found during scan window. "
+                    "Check Bluetooth adapter and sensor proximity."
+                )
+
+            if self.WaitForExit("TankCheckThread", self.poll_frequency * 60):
+                return
+
+    # ------------------------------------------------------------------
+    def Close(self):
+        self.running = False
+        if getattr(self, "Generator", None):
+            try:
+                self.Generator.Close()
+            except Exception:
+                pass
+        super(GenOtodataData, self).Close()
+
+
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    (console, ConfigFilePath, address, port, loglocation, log) = (
+        MySupport.SetupAddOnProgram("genotodata")
+    )
+
+    instance = GenOtodataData(
+        log=log,
+        loglocation=loglocation,
+        ConfigFilePath=ConfigFilePath,
+        host=address,
+        port=port,
+        console=console,
+    )
+
+    while instance.running:
+        time.sleep(0.5)
+
+    instance.Close()
+    sys.exit(0)

--- a/conf/genloader.conf
+++ b/conf/genloader.conf
@@ -246,3 +246,11 @@ postloaddelay = 0
 
 [genloader]
 version =
+
+[genotodata]
+module = genotodata.py
+enable = False
+hardstop = False
+conffile = genotodata.conf
+args =
+priority = 2

--- a/conf/genotodata.conf
+++ b/conf/genotodata.conf
@@ -1,0 +1,21 @@
+[genotodata]
+
+# Display name for this tank in the genmon web interface.
+tank_name = Propane Tank
+
+# Tank capacity in gallons.
+# Set to 0 to omit the capacity value from genmon data.
+capacity = 0
+
+# Number of minutes between BLE scan cycles.
+# The Otodata sensor broadcasts continuously so 5 minutes is a safe default.
+poll_frequency = 5
+
+# Seconds to listen for BLE advertisements during each scan cycle.
+# Increase this value if the sensor is far from the Pi or readings are missed.
+scan_time = 30
+
+# Optional: restrict readings to a specific sensor by Bluetooth MAC address.
+# Must be in the format aa:bb:cc:dd:ee:ff (hex, colon-separated).
+# Leave blank to accept the first device that broadcasts an Otodata level string.
+mac_address =

--- a/genserv.py
+++ b/genserv.py
@@ -2955,6 +2955,80 @@ def GetAddOns():
     return AddOnCfg
 
 
+        # GENOTODATA
+        if sys.version_info >= (3, 7):
+            Description = "Support Otodata TM6030 Propane Tank Sensor"
+            try:
+                import bleak
+            except Exception as e1:
+                Description = (
+                    Description
+                    + "<br/><font color='red'>The required libraries for this add on "
+                    "are not installed, please run the installation script.</font>"
+                )
+
+            AddOnCfg["genotodata"] = collections.OrderedDict()
+            AddOnCfg["genotodata"]["enable"] = ConfigFiles[GENLOADER_CONFIG].ReadValue(
+                "enable", return_type=bool, section="genotodata", default=False
+            )
+            AddOnCfg["genotodata"]["title"] = "Otodata TM6030 Propane Tank Sensor"
+            AddOnCfg["genotodata"]["description"] = Description
+            AddOnCfg["genotodata"]["icon"] = "mopeka"
+            AddOnCfg["genotodata"]["url"] = (
+                "https://github.com/jgyates/genmon/wiki/"
+                "1----Software-Overview#genototadatapy-optional"
+            )
+            AddOnCfg["genotodata"]["parameters"] = collections.OrderedDict()
+
+            AddOnCfg["genotodata"]["parameters"]["tank_name"] = CreateAddOnParam(
+                ConfigFiles[GENOTODATA_CONFIG].ReadValue(
+                    "tank_name", return_type=str, default="Propane Tank"
+                ),
+                "string",
+                "Display name for this tank in the genmon web interface.",
+                bounds="",
+                display_name="Tank Name",
+            )
+            AddOnCfg["genotodata"]["parameters"]["capacity"] = CreateAddOnParam(
+                ConfigFiles[GENOTODATA_CONFIG].ReadValue(
+                    "capacity", return_type=int, default=0
+                ),
+                "int",
+                "Tank capacity in gallons. Set to 0 to omit from genmon data.",
+                bounds="number",
+                display_name="Tank Capacity (gallons)",
+            )
+            AddOnCfg["genotodata"]["parameters"]["poll_frequency"] = CreateAddOnParam(
+                ConfigFiles[GENOTODATA_CONFIG].ReadValue(
+                    "poll_frequency", return_type=int, default=5
+                ),
+                "int",
+                "The time in minutes between BLE scan cycles. Default is 5 minutes.",
+                bounds="number",
+                display_name="Poll Interval (minutes)",
+            )
+            AddOnCfg["genotodata"]["parameters"]["scan_time"] = CreateAddOnParam(
+                ConfigFiles[GENOTODATA_CONFIG].ReadValue(
+                    "scan_time", return_type=float, default=30.0
+                ),
+                "float",
+                "Seconds to listen for BLE advertisements per scan cycle. "
+                "Increase if the sensor is far from the Pi.",
+                bounds="number",
+                display_name="Scan Duration (seconds)",
+            )
+            AddOnCfg["genotodata"]["parameters"]["mac_address"] = CreateAddOnParam(
+                ConfigFiles[GENOTODATA_CONFIG].ReadValue(
+                    "mac_address", return_type=str, default=""
+                ),
+                "string",
+                "Optional: restrict readings to a specific sensor MAC address "
+                "(e.g. aa:bb:cc:dd:ee:ff). Leave blank to use the first Otodata device found.",
+                bounds="",
+                display_name="Sensor MAC Address",
+            )
+
+
 # ------------ AddNotificationAddOnParam ----------------------------------------
 def AddNotificationAddOnParam(AddOnCfg, addon_name, config_file):
 
@@ -3129,6 +3203,7 @@ def SaveAddOnSettings(query_string):
             "gentemp": ConfigFiles[GENTEMP_CONFIG],
             "gencthat": ConfigFiles[GENCTHAT_CONFIG],
             "genmopeka": ConfigFiles[GENMOPEKA_CONFIG],
+            "genotodata": ConfigFiles[GENOTODATA_CONFIG],
             "gensms_voip": ConfigFiles[GENSMS_VOIP_CONFIG],
             "genhomeassistant": ConfigFiles[GENHOMEASSISTANT_CONFIG],
             "genhalink": ConfigFiles[GENHALINK_CONFIG],
@@ -6679,6 +6754,7 @@ if __name__ == "__main__":
     GENTEMP_CONFIG = os.path.join(ConfigFilePath, "gentemp.conf")
     GENCTHAT_CONFIG = os.path.join(ConfigFilePath, "gencthat.conf")
     GENMOPEKA_CONFIG = os.path.join(ConfigFilePath, "genmopeka.conf")
+    GENOTODATA_CONFIG = os.path.join(ConfigFilePath, "genotodata.conf")
     GENSMS_VOIP_CONFIG = os.path.join(ConfigFilePath, "gensms_voip.conf")
     GENHOMEASSISTANT_CONFIG = os.path.join(ConfigFilePath, "genhomeassistant.conf")
     GENHALINK_CONFIG = os.path.join(ConfigFilePath, "genhalink.conf")

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ smbus
 psutil
 spidev
 bleson @ git+https://github.com/TheCellule/python-bleson
+bleak
 # This breaks on 32 bit trixie and takes a long time on slower systems like the pi3 and pi zero 
 # so I am removing it from the base install
 #fluids


### PR DESCRIPTION
> **Add Otodata TM6030 BLE propane tank sensor addon (`genotodata`)**
>
> The Otodata TM6030 is a Bluetooth Low Energy sensor that straps to a
> standard propane tank and broadcasts the fill level as a percentage in its
> BLE advertisement name.  This addon scans for that advertisement and
> forwards the reading to genmon via `set_tank_data`, displaying it alongside
> generator fuel data in the web UI.
>
> **Changes:**
> - `addon/genotodata.py` — new addon script using `bleak` for BLE scanning
> - `conf/genotodata.conf` — configuration template
> - `conf/genloader.conf` — add disabled-by-default `[genotodata]` section
> - `requirements.txt` — add `bleak`
> - `genserv.py` — register addon in `GetAddOns()` for web UI toggle support
>
> **Similar to:** `genmopeka.py` (also a BLE propane tank sensor addon).
> The main difference is that the Otodata sensor broadcasts level as a plain
> percentage in the advertisement name, so no tank geometry calculations are
> needed and the `fluids` dependency is not required.
>
> **Tested on:** Raspberry Pi 4, Raspberry Pi OS Bookworm, Python 3.11,
> bleak 0.21, Otodata TM6030.