### PR TITLE
Add HTML Email toggle in settings

### DIFF
--- a/data/tooltips.txt
+++ b/data/tooltips.txt
@@ -12,6 +12,7 @@ imap_server = Server address used for receiving email, leave empty to disable IM
 smtp_port = SMTP port used on the SMTP server for sending email. Typically port 587 is used for TLS and port 465 is used for SSL
 ssl_enabled = Use SSL encryption to send emails
 tls_disable = If SSL is disabled TLS encryption is the default, unless this is enabled. If enabled and SSL is disabled, no encryption will be used to send email.
+use_html = Send a structured HTML alternative (in addition to plain text) so screen readers get clear pauses between status lines.
 smtpauth_disable = If enabled, ignore SMTP authentication. Typically only used for locally administered SMTP servers
 sitename = Site Name
 port = Serial device name of your serial port. Normally  /dev/serial0 or /dev/ttyAMA0 for onboard Raspberry Pi Serial ports

--- a/genserv.py
+++ b/genserv.py
@@ -1103,6 +1103,7 @@ def SendTestEmail(query_string):
         use_ssl = parameters["use_ssl"] in (True, "true", "True", "1", 1)
         tls_disable = parameters["tls_disable"] in (True, "true", "True", "1", 1)
         smtpauth_disable = parameters["smtpauth_disable"] in (True, "true", "True", "1", 1)
+        use_html = parameters.get("use_html", False) in (True, "true", "True", "1", 1)
 
     except Exception as e1:
         LogErrorLine("Error parsing parameters in SendTestEmail: " + str(e1))
@@ -1121,6 +1122,7 @@ def SendTestEmail(query_string):
             use_ssl=use_ssl,
             tls_disable=tls_disable,
             smtpauth_disable=smtpauth_disable,
+            use_html=use_html,
         )
         return jsonify({"message": ReturnMessage})
     except Exception as e1:
@@ -5031,6 +5033,17 @@ def ReadSettingsFromFile():
         MAIL_CONFIG,
         MAIL_SECTION,
         "tls_disable",
+    ]
+    ConfigSettings["use_html"] = [
+        "boolean",
+        "Use HTML Email Format",
+        310,
+        False,
+        "",
+        "",
+        MAIL_CONFIG,
+        MAIL_SECTION,
+        "use_html",
     ]
     ConfigSettings["smtpauth_disable"] = [
         "boolean",

--- a/static/js/genmon.js
+++ b/static/js/genmon.js
@@ -4330,7 +4330,7 @@ var Pages = {
         usemfa:          { disables:['mfa_url','mfa_trust_extend','mfa_trust_days'], when:false },
         mfa_trust_extend:{ disables:['mfa_trust_days'], when:false },
         use_serial_tcp:  { disables:['serial_tcp_address','serial_tcp_port','modbus_tcp','serial_tcp_keepalive'], when:false },
-        disablesmtp:     { disables:['email_account','email_pw','sender_account','sender_name','smtp_server','smtp_port','ssl_enabled','tls_disable','smtpauth_disable'], when:false },
+        disablesmtp:     { disables:['email_account','email_pw','sender_account','sender_name','smtp_server','smtp_port','ssl_enabled','tls_disable','use_html','smtpauth_disable'], when:false },
         disableimap:     { disables:['imap_server','readonlyemailcommands','incoming_mail_folder','processed_mail_folder'], when:false },
         disableoutagecheck: { disables:[], when:false },
         disablepowerlog:    { disables:[], when:false }
@@ -4341,7 +4341,7 @@ var Pages = {
         { id:'email-smtp', toggle:'disablesmtp', label:'Outbound Email (SMTP)',
           icon:'upload',
           desc:'Configure an SMTP server to send email alerts and notifications.',
-          fields:['email_account','email_pw','sender_account','sender_name','smtp_server','smtp_port','ssl_enabled','smtpauth_disable','tls_disable'] },
+          fields:['email_account','email_pw','sender_account','sender_name','smtp_server','smtp_port','ssl_enabled','smtpauth_disable','tls_disable','use_html'] },
         { id:'email-imap', toggle:'disableimap', label:'Inbound Email Commands (IMAP)',
           icon:'download',
           desc:'Allow genmon to receive and process commands via email.',
@@ -5454,7 +5454,8 @@ var Pages = {
             password:        $w.find('#f_email_pw').val(),
             use_ssl:        ($w.find('#f_ssl_enabled').is(':checked')),
             tls_disable:    ($w.find('#f_tls_disable').is(':checked')),
-            smtpauth_disable:($w.find('#f_smtpauth_disable').is(':checked'))
+            smtpauth_disable:($w.find('#f_smtpauth_disable').is(':checked')),
+            use_html:       ($w.find('#f_use_html').is(':checked'))
           });
           API.get('test_email?test_email=' + encodeURIComponent(payload), 15000)
             .done(function(r) {


### PR DESCRIPTION
# Pull Request Template

## Description

Change adds an email button to toggle the existing use html email flag.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Toggle flag on - observe emails sent at startup, both the startup and the first notice.
- [X] Toggle flag off - observe emails sent at startup, both the startup and the first notice.

**Test Configuration**:
* Firmware version: N/A
* Hardware: N/A

## Checklist:

- [ ] Are any new libraries required and have they been added to the install scripts
- [X] My code follows the existing code style and formatting of this project
- [X] I have performed a self-review of my own code
- [X] I have reasonably commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings or errors
- [X] I have checked my code and corrected any misspellings
- [X] I have tested any python code on 3.x
- [X] I have tested any javascript on most popular browsers for compatibility
