### PR TITLE
Fix genserv.py SyntaxError on Python < 3.12 (web UI never starts)

### DIFF
--- a/genserv.py
+++ b/genserv.py
@@ -693,7 +693,7 @@ def do_admin_login():
         CheckFailedLogin()
         return _render_login()
     else:
-        LogError(f"Unknown login error: user: {request.form["username"]}")
+        LogError(f"Unknown login error: user: {request.form['username']}")
         LogError(f"admin ok: {admin_user_ok}, admin pass ok: {admin_pass_ok}, ro user: {ro_user_ok}, ro pass: {ro_pass_ok}")
         return _render_login()
 


### PR DESCRIPTION
## Description

`do_admin_login` in `genserv.py` used a Python 3.12-only nested f-string (same quote character inside the expression as around the f-string). On Python 3.9–3.11 that is a `SyntaxError: f-string: unmatched '['` at import time, so `genserv.py` never starts and nothing listens on port 8000. `genmon.py` still loads, which is why status emails work and `genmon.log` looks healthy.

Genmon 2.0 documents Python 3.9+; swapping the inner quotes restores that.

Fixes #1522

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `python3 -m py_compile genserv.py` on Python 3.9.6 (documented minimum)
- Reproduced the crash on Python 3.11.5 (`m0ngr31/genmon:weekly-2026-08-26`, built FROM `python:3.11.5-slim-bookworm`): running genserv printed the SyntaxError and the web UI stayed down at two independent sites after that weekly image cloned this master commit.

**Test Configuration**:
* Firmware version: n/a (import-time syntax, independent of controller)
* Hardware: Raspberry Pi 3 / bullseye (reporter on #1522, Python 3.9) and Docker Python 3.11.5

## Checklist:

- [x] Are any new libraries required and have they been added to the install scripts
- [x] My code follows the existing code style and formatting of this project
- [x] I have performed a self-review of my own code
- [x] I have reasonably commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have checked my code and corrected any misspellings
- [x] I have tested any python code on 3.x
- [x] I have tested any javascript on most popular browsers for compatibility
